### PR TITLE
Include <stdexcept> in necessary files

### DIFF
--- a/tools/preproc/asm_file.cpp
+++ b/tools/preproc/asm_file.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdio>
 #include <cstdarg>
+#include <stdexcept>
 #include "preproc.h"
 #include "asm_file.h"
 #include "char_util.h"

--- a/tools/preproc/c_file.cpp
+++ b/tools/preproc/c_file.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdio>
 #include <cstdarg>
+#include <stdexcept>
 #include <string>
 #include <memory>
 #include "preproc.h"


### PR DESCRIPTION
## Description
Adds `#include <stdexcept>` to two files in preproc. This fixes an issue where `make tools` may fail on some distros because `<stdexcept>` is not found automatically.

## **Discord contact info**
WhenGryphonsFly#2089