### PR TITLE
Update Makefile to support building without devkitPro

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,6 +19,7 @@ Install the **devkitARM** toolchain of [devkitPro](https://devkitpro.org/wiki/Ge
 	export DEVKITARM=$DEVKITPRO/devkitARM
 	echo "export DEVKITARM=$DEVKITARM" >> ~/.bashrc
 
+As an alternative to installing devkitARM, for Linux users only, install the GNU Arm Embedded Toolchain. For Debian/Ubuntu-based distributions, this can be accomplished with `sudo apt install gcc-arm-none-eabi binutils-arm-none-eabi`. For Arch Linux, this can be accomplished with `pacman -S arm-none-eabi-gcc arm-none-eabi-binutils`.
 
 # Installation
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
-include $(DEVKITARM)/base_tools
+TOOLCHAIN := $(DEVKITARM)
+ifneq (,$(TOOLCHAIN))
+ifneq ($(wildcard $(TOOLCHAIN)/bin),)
+export PATH := $(TOOLCHAIN)/bin:$(PATH)
+endif
+endif
+
+PREFIX := arm-none-eabi-
+OBJCOPY := $(PREFIX)objcopy
+AS := $(PREFIX)as
+
 export CPP := $(PREFIX)cpp
 export LD := $(PREFIX)ld
 


### PR DESCRIPTION
## Description
Updates the makefile to support building without installing devkitPro.

Note 1: I know very little of how make works, and I basically just copied and pasted parts from the latest pokeemerald makefile. With that said, I have confirmed that this makefile works in Linux Mint 21.1 both with devkitPro and without (at least, it builds in both of my VMs when combined with the `stdexcept` patch as in #13).

Note 2: This pull request does not currently update INSTALL.md.

## **Discord contact info**
WhenGryphonsFly#2089