### PR TITLE
Add comment to explain unk73D

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -127,7 +127,7 @@ struct PinballGame
 	/*0x602*/ u8 filler602[0x126];
 	/*0x728*/ u8 unk728; // TODO: unknown type
 	/*0x729*/ u8 filler729[0x14];
-	/*0x73D*/ s8 unk73D;
+	/*0x73D*/ s8 unk73D; // Number of catch mode arrows lit
 };
 
 struct Unk02031520


### PR DESCRIPTION
Add comment to explain the usage of unk73D

## Description
This variable is inferred from rom_3219C.c, where rare pokemon only appears when unk73D is equal to 3; in the actual game species that appear are different when the number of arrows lit is 2 vs 3.

## **Discord contact info**
ney3538