### PR TITLE
Name known ball related fields (unk10; unk28; unk2C; renames position, prevPosition) and unk132c

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -86,17 +86,17 @@ struct BallState
     /*0x0A*/ u16 unkA;
     /*0x0C*/ u16 unkC;
     /*0x0E*/ u16 unkE;
-    /*0x10*/ struct Vector16 logicPosition;
+    /*0x10*/ struct Vector16 positionQ0;
     /*0x14*/ u8 filler14[0xB];
     /*0x1F*/ u8 unk1F;
     /*0x20*/ u8 filler20[0x4];
     /*0x24*/ u16 unk24;
     /*0x26*/ u16 unk26;
-    /*0x28*/ struct Vector16 halfPxPosition; // double the values of the logicPosition
-    /*0x2C*/ struct Vector16 prevHalfPxPosition;
+    /*0x28*/ struct Vector16 positionQ1; // double the values of the logicPosition
+    /*0x2C*/ struct Vector16 prevPositionQ1;
     /*0x30*/ struct Vector16 velocity;
-    /*0x34*/ struct Vector32 physicsPosition; // fixed-point Q_24_8 values; position as used by physics calculation
-    /*0x3C*/ struct Vector32 prevPhysicsPosition;
+    /*0x34*/ struct Vector32 positionQ8; // fixed-point Q_24_8 values; position as used by physics calculation
+    /*0x3C*/ struct Vector32 prevPositionQ8;
 };
 
 struct UnkPinballGame13BC
@@ -490,7 +490,7 @@ struct PinballGame
     /*0x1326*/s16 unk1326;
     /*0x1328*/u16 unk1328;
     /*0x132A*/u8 filler132A[0x2];
-    /*0x132C*/struct BallState *pokeball;
+    /*0x132C*/struct BallState *ball;
     /*0x1330*/struct BallState *unk1330;
     /*0x1334*/struct BallState unk1334[2];
     /*0x13BC*/struct UnkPinballGame13BC unk13BC[2];

--- a/include/global.h
+++ b/include/global.h
@@ -86,17 +86,17 @@ struct BallState
     /*0x0A*/ u16 unkA;
     /*0x0C*/ u16 unkC;
     /*0x0E*/ u16 unkE;
-    /*0x10*/ struct Vector16 unk10;
+    /*0x10*/ struct Vector16 logicPosition;
     /*0x14*/ u8 filler14[0xB];
     /*0x1F*/ u8 unk1F;
     /*0x20*/ u8 filler20[0x4];
     /*0x24*/ u16 unk24;
     /*0x26*/ u16 unk26;
-    /*0x28*/ struct Vector16 unk28;
-    /*0x2C*/ struct Vector16 unk2C;
+    /*0x28*/ struct Vector16 halfPxPosition; // double the values of the logicPosition
+    /*0x2C*/ struct Vector16 prevHalfPxPosition;
     /*0x30*/ struct Vector16 velocity;
-    /*0x34*/ struct Vector32 position; // fixed-point Q_24_8 values
-    /*0x3C*/ struct Vector32 prevPosition;
+    /*0x34*/ struct Vector32 physicsPosition; // fixed-point Q_24_8 values; position as used by physics calculation
+    /*0x3C*/ struct Vector32 prevPhysicsPosition;
 };
 
 struct UnkPinballGame13BC
@@ -490,7 +490,7 @@ struct PinballGame
     /*0x1326*/s16 unk1326;
     /*0x1328*/u16 unk1328;
     /*0x132A*/u8 filler132A[0x2];
-    /*0x132C*/struct BallState *unk132c;
+    /*0x132C*/struct BallState *pokeball;
     /*0x1330*/struct BallState *unk1330;
     /*0x1334*/struct BallState unk1334[2];
     /*0x13BC*/struct UnkPinballGame13BC unk13BC[2];

--- a/include/global.h
+++ b/include/global.h
@@ -92,10 +92,10 @@ struct BallState
     /*0x20*/ u8 filler20[0x4];
     /*0x24*/ u16 unk24;
     /*0x26*/ u16 unk26;
-    /*0x28*/ struct Vector16 positionQ1; // double the values of the logicPosition
+    /*0x28*/ struct Vector16 positionQ1;
     /*0x2C*/ struct Vector16 prevPositionQ1;
     /*0x30*/ struct Vector16 velocity;
-    /*0x34*/ struct Vector32 positionQ8; // fixed-point Q_24_8 values; position as used by physics calculation
+    /*0x34*/ struct Vector32 positionQ8; // fixed-point Q_24_8 values
     /*0x3C*/ struct Vector32 prevPositionQ8;
 };
 

--- a/src/pinball_game_main.c
+++ b/src/pinball_game_main.c
@@ -383,7 +383,7 @@ void sub_4A518(void)
 
     gCurrentPinballGame->unk38 = 40000;
     gCurrentPinballGame->unk1D = 0;
-    gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
+    gCurrentPinballGame->ball = &gCurrentPinballGame->unk1334[0];
     gCurrentPinballGame->unk1330 = &gCurrentPinballGame->unk1334[0];
     gCurrentPinballGame->unk66 = 0;
 }
@@ -393,15 +393,15 @@ void sub_4A6A0(void)
     switch (gCurrentPinballGame->unk282)
     {
     case 0:
-        gCurrentPinballGame->pokeball->logicPosition.x = 119;
-        gCurrentPinballGame->pokeball->logicPosition.y = 279;
-        gCurrentPinballGame->pokeball->velocity.x = 0;
-        gCurrentPinballGame->pokeball->velocity.y = 0;
-        gCurrentPinballGame->pokeball->unk6 = 0;
-        gCurrentPinballGame->pokeball->physicsPosition.x = gCurrentPinballGame->pokeball->logicPosition.x << 8;
-        gCurrentPinballGame->pokeball->physicsPosition.y = gCurrentPinballGame->pokeball->logicPosition.y << 8;
-        gCurrentPinballGame->pokeball->unkE = 128;
-        gCurrentPinballGame->pokeball->unk0 = 1;
+        gCurrentPinballGame->ball->positionQ0.x = 119;
+        gCurrentPinballGame->ball->positionQ0.y = 279;
+        gCurrentPinballGame->ball->velocity.x = 0;
+        gCurrentPinballGame->ball->velocity.y = 0;
+        gCurrentPinballGame->ball->unk6 = 0;
+        gCurrentPinballGame->ball->positionQ8.x = gCurrentPinballGame->ball->positionQ0.x << 8;
+        gCurrentPinballGame->ball->positionQ8.y = gCurrentPinballGame->ball->positionQ0.y << 8;
+        gCurrentPinballGame->ball->unkE = 128;
+        gCurrentPinballGame->ball->unk0 = 1;
         gCurrentPinballGame->unk1F = 1;
         gCurrentPinballGame->unk730 = 0;
         gCurrentPinballGame->unk28 = 120;
@@ -415,15 +415,15 @@ void sub_4A6A0(void)
         gCurrentPinballGame->unk4E = 215;
         break;
     case 1:
-        gCurrentPinballGame->pokeball->logicPosition.x = 140;
-        gCurrentPinballGame->pokeball->logicPosition.y = 183;
-        gCurrentPinballGame->pokeball->velocity.x = 0;
-        gCurrentPinballGame->pokeball->velocity.y = 0;
-        gCurrentPinballGame->pokeball->unk6 = 0;
-        gCurrentPinballGame->pokeball->physicsPosition.x = gCurrentPinballGame->pokeball->logicPosition.x << 8;
-        gCurrentPinballGame->pokeball->physicsPosition.y = gCurrentPinballGame->pokeball->logicPosition.y << 8;
-        gCurrentPinballGame->pokeball->unkE = 128;
-        gCurrentPinballGame->pokeball->unk0 = 1;
+        gCurrentPinballGame->ball->positionQ0.x = 140;
+        gCurrentPinballGame->ball->positionQ0.y = 183;
+        gCurrentPinballGame->ball->velocity.x = 0;
+        gCurrentPinballGame->ball->velocity.y = 0;
+        gCurrentPinballGame->ball->unk6 = 0;
+        gCurrentPinballGame->ball->positionQ8.x = gCurrentPinballGame->ball->positionQ0.x << 8;
+        gCurrentPinballGame->ball->positionQ8.y = gCurrentPinballGame->ball->positionQ0.y << 8;
+        gCurrentPinballGame->ball->unkE = 128;
+        gCurrentPinballGame->ball->unk0 = 1;
         gCurrentPinballGame->unk1F = 1;
         gCurrentPinballGame->unk730 = 0;
         gCurrentPinballGame->unk2A2 = 5;
@@ -431,15 +431,15 @@ void sub_4A6A0(void)
         gCurrentPinballGame->unk4E = 118;
         break;
     case 2:
-        gCurrentPinballGame->pokeball->logicPosition.x = -28;
-        gCurrentPinballGame->pokeball->logicPosition.y = -10;
-        gCurrentPinballGame->pokeball->velocity.x = 0;
-        gCurrentPinballGame->pokeball->velocity.y = 0;
-        gCurrentPinballGame->pokeball->unk6 = 0;
-        gCurrentPinballGame->pokeball->physicsPosition.x = gCurrentPinballGame->pokeball->logicPosition.x << 8;
-        gCurrentPinballGame->pokeball->physicsPosition.y = gCurrentPinballGame->pokeball->logicPosition.y << 8;
-        gCurrentPinballGame->pokeball->unkE = 128;
-        gCurrentPinballGame->pokeball->unk0 = 1;
+        gCurrentPinballGame->ball->positionQ0.x = -28;
+        gCurrentPinballGame->ball->positionQ0.y = -10;
+        gCurrentPinballGame->ball->velocity.x = 0;
+        gCurrentPinballGame->ball->velocity.y = 0;
+        gCurrentPinballGame->ball->unk6 = 0;
+        gCurrentPinballGame->ball->positionQ8.x = gCurrentPinballGame->ball->positionQ0.x << 8;
+        gCurrentPinballGame->ball->positionQ8.y = gCurrentPinballGame->ball->positionQ0.y << 8;
+        gCurrentPinballGame->ball->unkE = 128;
+        gCurrentPinballGame->ball->unk0 = 1;
         gCurrentPinballGame->unk1F = 1;
         gCurrentPinballGame->unk730 = 0;
         gCurrentPinballGame->unk30C = 0;
@@ -753,7 +753,7 @@ void sub_4AE8C(void)
             for (i = 0; i < 4; i++)
             {
                 gCurrentPinballGame->unk66 = 0;
-                gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
+                gCurrentPinballGame->ball = &gCurrentPinballGame->unk1334[0];
                 gCurrentPinballGame->unk1E = i;
                 gUnknown_020028D8[6].unk4();
             }
@@ -768,7 +768,7 @@ void sub_4AE8C(void)
             if (gCurrentPinballGame->unk1F == 2)
             {
                 gCurrentPinballGame->unk66 = 0;
-                gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
+                gCurrentPinballGame->ball = &gCurrentPinballGame->unk1334[0];
                 gCurrentPinballGame->unk1E = 0;
             }
             else
@@ -776,7 +776,7 @@ void sub_4AE8C(void)
                 for (i = 0; i < 4; i++)
                 {
                     gCurrentPinballGame->unk66 = 0;
-                    gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
+                    gCurrentPinballGame->ball = &gCurrentPinballGame->unk1334[0];
                     gCurrentPinballGame->unk1E = i;
                     gUnknown_020028D8[5].unk4();
                 }
@@ -787,7 +787,7 @@ void sub_4AE8C(void)
             for (i = 0; i < 4; i++)
             {
                 gCurrentPinballGame->unk66 = 0;
-                gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
+                gCurrentPinballGame->ball = &gCurrentPinballGame->unk1334[0];
                 gCurrentPinballGame->unk1E = i;
                 gUnknown_020028D8[5].unk4();
                 gUnknown_020028D8[6].unk4();
@@ -817,7 +817,7 @@ void sub_4B000(void)
                 for (i = 0; i < 4; i++)
                 {
                     gCurrentPinballGame->unk66 = 0;
-                    gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
+                    gCurrentPinballGame->ball = &gCurrentPinballGame->unk1334[0];
                     gCurrentPinballGame->unk1E = i;
                     gUnknown_020028D8[6].unk4();
                 }
@@ -832,7 +832,7 @@ void sub_4B000(void)
                 if (gCurrentPinballGame->unk1F == 2)
                 {
                     gCurrentPinballGame->unk66 = 0;
-                    gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
+                    gCurrentPinballGame->ball = &gCurrentPinballGame->unk1334[0];
                     gCurrentPinballGame->unk1E = 0;
                 }
                 else
@@ -840,7 +840,7 @@ void sub_4B000(void)
                     for (i = 0; i < 4; i++)
                     {
                         gCurrentPinballGame->unk66 = 0;
-                        gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
+                        gCurrentPinballGame->ball = &gCurrentPinballGame->unk1334[0];
                         gCurrentPinballGame->unk1E = i;
                         gUnknown_020028D8[5].unk4();
                     }
@@ -851,7 +851,7 @@ void sub_4B000(void)
                 for (i = 0; i < 4; i++)
                 {
                     gCurrentPinballGame->unk66 = 0;
-                    gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
+                    gCurrentPinballGame->ball = &gCurrentPinballGame->unk1334[0];
                     gCurrentPinballGame->unk1E = i;
                     gUnknown_020028D8[5].unk4();
                     gUnknown_020028D8[6].unk4();
@@ -1043,7 +1043,7 @@ void sub_4B678(u16 arg0)
     else if (arg0 == 2)
     {
         DmaCopy16(3, gUnknown_02031520.unkC, gCurrentPinballGame, sizeof(*gCurrentPinballGame));
-        gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
+        gCurrentPinballGame->ball = &gCurrentPinballGame->unk1334[0];
         gCurrentPinballGame->unk1330 = &gCurrentPinballGame->unk1334[0];
         var2 = gMain.unk30;
         if ((var2 & 0x3) == 1)

--- a/src/pinball_game_main.c
+++ b/src/pinball_game_main.c
@@ -383,7 +383,7 @@ void sub_4A518(void)
 
     gCurrentPinballGame->unk38 = 40000;
     gCurrentPinballGame->unk1D = 0;
-    gCurrentPinballGame->unk132c = &gCurrentPinballGame->unk1334[0];
+    gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
     gCurrentPinballGame->unk1330 = &gCurrentPinballGame->unk1334[0];
     gCurrentPinballGame->unk66 = 0;
 }
@@ -393,15 +393,15 @@ void sub_4A6A0(void)
     switch (gCurrentPinballGame->unk282)
     {
     case 0:
-        gCurrentPinballGame->unk132c->unk10.x = 119;
-        gCurrentPinballGame->unk132c->unk10.y = 279;
-        gCurrentPinballGame->unk132c->velocity.x = 0;
-        gCurrentPinballGame->unk132c->velocity.y = 0;
-        gCurrentPinballGame->unk132c->unk6 = 0;
-        gCurrentPinballGame->unk132c->position.x = gCurrentPinballGame->unk132c->unk10.x << 8;
-        gCurrentPinballGame->unk132c->position.y = gCurrentPinballGame->unk132c->unk10.y << 8;
-        gCurrentPinballGame->unk132c->unkE = 128;
-        gCurrentPinballGame->unk132c->unk0 = 1;
+        gCurrentPinballGame->pokeball->logicPosition.x = 119;
+        gCurrentPinballGame->pokeball->logicPosition.y = 279;
+        gCurrentPinballGame->pokeball->velocity.x = 0;
+        gCurrentPinballGame->pokeball->velocity.y = 0;
+        gCurrentPinballGame->pokeball->unk6 = 0;
+        gCurrentPinballGame->pokeball->physicsPosition.x = gCurrentPinballGame->pokeball->logicPosition.x << 8;
+        gCurrentPinballGame->pokeball->physicsPosition.y = gCurrentPinballGame->pokeball->logicPosition.y << 8;
+        gCurrentPinballGame->pokeball->unkE = 128;
+        gCurrentPinballGame->pokeball->unk0 = 1;
         gCurrentPinballGame->unk1F = 1;
         gCurrentPinballGame->unk730 = 0;
         gCurrentPinballGame->unk28 = 120;
@@ -415,15 +415,15 @@ void sub_4A6A0(void)
         gCurrentPinballGame->unk4E = 215;
         break;
     case 1:
-        gCurrentPinballGame->unk132c->unk10.x = 140;
-        gCurrentPinballGame->unk132c->unk10.y = 183;
-        gCurrentPinballGame->unk132c->velocity.x = 0;
-        gCurrentPinballGame->unk132c->velocity.y = 0;
-        gCurrentPinballGame->unk132c->unk6 = 0;
-        gCurrentPinballGame->unk132c->position.x = gCurrentPinballGame->unk132c->unk10.x << 8;
-        gCurrentPinballGame->unk132c->position.y = gCurrentPinballGame->unk132c->unk10.y << 8;
-        gCurrentPinballGame->unk132c->unkE = 128;
-        gCurrentPinballGame->unk132c->unk0 = 1;
+        gCurrentPinballGame->pokeball->logicPosition.x = 140;
+        gCurrentPinballGame->pokeball->logicPosition.y = 183;
+        gCurrentPinballGame->pokeball->velocity.x = 0;
+        gCurrentPinballGame->pokeball->velocity.y = 0;
+        gCurrentPinballGame->pokeball->unk6 = 0;
+        gCurrentPinballGame->pokeball->physicsPosition.x = gCurrentPinballGame->pokeball->logicPosition.x << 8;
+        gCurrentPinballGame->pokeball->physicsPosition.y = gCurrentPinballGame->pokeball->logicPosition.y << 8;
+        gCurrentPinballGame->pokeball->unkE = 128;
+        gCurrentPinballGame->pokeball->unk0 = 1;
         gCurrentPinballGame->unk1F = 1;
         gCurrentPinballGame->unk730 = 0;
         gCurrentPinballGame->unk2A2 = 5;
@@ -431,15 +431,15 @@ void sub_4A6A0(void)
         gCurrentPinballGame->unk4E = 118;
         break;
     case 2:
-        gCurrentPinballGame->unk132c->unk10.x = -28;
-        gCurrentPinballGame->unk132c->unk10.y = -10;
-        gCurrentPinballGame->unk132c->velocity.x = 0;
-        gCurrentPinballGame->unk132c->velocity.y = 0;
-        gCurrentPinballGame->unk132c->unk6 = 0;
-        gCurrentPinballGame->unk132c->position.x = gCurrentPinballGame->unk132c->unk10.x << 8;
-        gCurrentPinballGame->unk132c->position.y = gCurrentPinballGame->unk132c->unk10.y << 8;
-        gCurrentPinballGame->unk132c->unkE = 128;
-        gCurrentPinballGame->unk132c->unk0 = 1;
+        gCurrentPinballGame->pokeball->logicPosition.x = -28;
+        gCurrentPinballGame->pokeball->logicPosition.y = -10;
+        gCurrentPinballGame->pokeball->velocity.x = 0;
+        gCurrentPinballGame->pokeball->velocity.y = 0;
+        gCurrentPinballGame->pokeball->unk6 = 0;
+        gCurrentPinballGame->pokeball->physicsPosition.x = gCurrentPinballGame->pokeball->logicPosition.x << 8;
+        gCurrentPinballGame->pokeball->physicsPosition.y = gCurrentPinballGame->pokeball->logicPosition.y << 8;
+        gCurrentPinballGame->pokeball->unkE = 128;
+        gCurrentPinballGame->pokeball->unk0 = 1;
         gCurrentPinballGame->unk1F = 1;
         gCurrentPinballGame->unk730 = 0;
         gCurrentPinballGame->unk30C = 0;
@@ -753,7 +753,7 @@ void sub_4AE8C(void)
             for (i = 0; i < 4; i++)
             {
                 gCurrentPinballGame->unk66 = 0;
-                gCurrentPinballGame->unk132c = &gCurrentPinballGame->unk1334[0];
+                gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
                 gCurrentPinballGame->unk1E = i;
                 gUnknown_020028D8[6].unk4();
             }
@@ -768,7 +768,7 @@ void sub_4AE8C(void)
             if (gCurrentPinballGame->unk1F == 2)
             {
                 gCurrentPinballGame->unk66 = 0;
-                gCurrentPinballGame->unk132c = &gCurrentPinballGame->unk1334[0];
+                gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
                 gCurrentPinballGame->unk1E = 0;
             }
             else
@@ -776,7 +776,7 @@ void sub_4AE8C(void)
                 for (i = 0; i < 4; i++)
                 {
                     gCurrentPinballGame->unk66 = 0;
-                    gCurrentPinballGame->unk132c = &gCurrentPinballGame->unk1334[0];
+                    gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
                     gCurrentPinballGame->unk1E = i;
                     gUnknown_020028D8[5].unk4();
                 }
@@ -787,7 +787,7 @@ void sub_4AE8C(void)
             for (i = 0; i < 4; i++)
             {
                 gCurrentPinballGame->unk66 = 0;
-                gCurrentPinballGame->unk132c = &gCurrentPinballGame->unk1334[0];
+                gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
                 gCurrentPinballGame->unk1E = i;
                 gUnknown_020028D8[5].unk4();
                 gUnknown_020028D8[6].unk4();
@@ -817,7 +817,7 @@ void sub_4B000(void)
                 for (i = 0; i < 4; i++)
                 {
                     gCurrentPinballGame->unk66 = 0;
-                    gCurrentPinballGame->unk132c = &gCurrentPinballGame->unk1334[0];
+                    gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
                     gCurrentPinballGame->unk1E = i;
                     gUnknown_020028D8[6].unk4();
                 }
@@ -832,7 +832,7 @@ void sub_4B000(void)
                 if (gCurrentPinballGame->unk1F == 2)
                 {
                     gCurrentPinballGame->unk66 = 0;
-                    gCurrentPinballGame->unk132c = &gCurrentPinballGame->unk1334[0];
+                    gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
                     gCurrentPinballGame->unk1E = 0;
                 }
                 else
@@ -840,7 +840,7 @@ void sub_4B000(void)
                     for (i = 0; i < 4; i++)
                     {
                         gCurrentPinballGame->unk66 = 0;
-                        gCurrentPinballGame->unk132c = &gCurrentPinballGame->unk1334[0];
+                        gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
                         gCurrentPinballGame->unk1E = i;
                         gUnknown_020028D8[5].unk4();
                     }
@@ -851,7 +851,7 @@ void sub_4B000(void)
                 for (i = 0; i < 4; i++)
                 {
                     gCurrentPinballGame->unk66 = 0;
-                    gCurrentPinballGame->unk132c = &gCurrentPinballGame->unk1334[0];
+                    gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
                     gCurrentPinballGame->unk1E = i;
                     gUnknown_020028D8[5].unk4();
                     gUnknown_020028D8[6].unk4();
@@ -1043,7 +1043,7 @@ void sub_4B678(u16 arg0)
     else if (arg0 == 2)
     {
         DmaCopy16(3, gUnknown_02031520.unkC, gCurrentPinballGame, sizeof(*gCurrentPinballGame));
-        gCurrentPinballGame->unk132c = &gCurrentPinballGame->unk1334[0];
+        gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
         gCurrentPinballGame->unk1330 = &gCurrentPinballGame->unk1334[0];
         var2 = gMain.unk30;
         if ((var2 & 0x3) == 1)

--- a/src/rom_11B9C.c
+++ b/src/rom_11B9C.c
@@ -20,7 +20,7 @@ void sub_11B9C(void)
     s16 i;
     if (gMain.unk6 == 0)
     {
-        gCurrentPinballGame->unk132c = &gCurrentPinballGame->unk1334[0];
+        gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
         sub_11C14(0);
         sub_12524();
     }
@@ -28,7 +28,7 @@ void sub_11B9C(void)
     {
         for (i = 0; i < 2; i++)
         {
-            gCurrentPinballGame->unk132c = &gCurrentPinballGame->unk1334[i];
+            gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[i];
             sub_11C14(i);
         }
         sub_12BF8();
@@ -38,12 +38,12 @@ void sub_11B9C(void)
 void sub_11C14(s16 arg0)
 {
     struct BallState *var0 = &gCurrentPinballGame->unk1334[arg0];
-    var0->unk10.x = gUnknown_02031520.unk26;
-    var0->unk10.y = gUnknown_02031520.unk28;
-    var0->position.x = Q_24_8(var0->unk10.x);
-    var0->position.y = Q_24_8(var0->unk10.y);
-    var0->unk28.x = gUnknown_02031520.unk26 * 2;
-    var0->unk28.y = gUnknown_02031520.unk28 * 2;
+    var0->logicPosition.x = gUnknown_02031520.unk26;
+    var0->logicPosition.y = gUnknown_02031520.unk28;
+    var0->physicsPosition.x = Q_24_8(var0->logicPosition.x);
+    var0->physicsPosition.y = Q_24_8(var0->logicPosition.y);
+    var0->halfPxPosition.x = gUnknown_02031520.unk26 * 2;
+    var0->halfPxPosition.y = gUnknown_02031520.unk28 * 2;
     var0->unkE = 0x100;
     var0->velocity.x = 0;
     var0->velocity.y = 0;
@@ -88,8 +88,8 @@ void sub_11C98(void)
     int squaredMagnitude;
     int maxSpeed;
 
-    unk132c = gCurrentPinballGame->unk132c;
-    unk132c->prevPosition = unk132c->position;
+    unk132c = gCurrentPinballGame->pokeball;
+    unk132c->prevPhysicsPosition = unk132c->physicsPosition;
     if (gCurrentPinballGame->unk5A4 != 2)
     {
         if (gCurrentPinballGame->ballSpeed != 0)
@@ -113,7 +113,7 @@ void sub_11C98(void)
             yy = unk132c->velocity.y * unk132c->velocity.y;
             squaredMagnitude = xx + yy;
 
-            if (unk132c->unk10.y < 380)
+            if (unk132c->logicPosition.y < 380)
             {
                 UPDATE_BALL_POSITION(272, angle);
             }
@@ -143,7 +143,7 @@ void sub_11C98(void)
             yy = unk132c->velocity.y * unk132c->velocity.y;
             squaredMagnitude = xx + yy;
 
-            if (unk132c->unk10.y < 380)
+            if (unk132c->logicPosition.y < 380)
             {
                 UPDATE_BALL_POSITION(336, angle);
             }
@@ -158,9 +158,9 @@ void sub_11C98(void)
         sub_2AADC();
     }
 
-    unk132c->unk2C = unk132c->unk28;
-    unk132c->unk28.x = (unk132c->position.x + 64) / 128;
-    unk132c->unk28.y = (unk132c->position.y + 64) / 128;
+    unk132c->prevHalfPxPosition = unk132c->halfPxPosition;
+    unk132c->halfPxPosition.x = (unk132c->physicsPosition.x + 64) / 128;
+    unk132c->halfPxPosition.y = (unk132c->physicsPosition.y + 64) / 128;
     unk132c->unk8 = unk132c->unk6;
     unk132c->unkA += unk132c->unk6;
 }
@@ -173,8 +173,8 @@ void sub_11F88(void)
     int squaredMagnitude;
     int maxSpeed;
 
-    unk132c = gCurrentPinballGame->unk132c;
-    unk132c->prevPosition = unk132c->position;
+    unk132c = gCurrentPinballGame->pokeball;
+    unk132c->prevPhysicsPosition = unk132c->physicsPosition;
     if (gCurrentPinballGame->unk5A4 != 2)
     {
         if (!gCurrentPinballGame->unk1F && !gCurrentPinballGame->unk383)
@@ -199,7 +199,7 @@ void sub_11F88(void)
 
             if (gMain.selectedField <= FIELD_KECLEON)
             {
-                if (unk132c->unk10.y < 150)
+                if (unk132c->logicPosition.y < 150)
                 {
                     UPDATE_BALL_POSITION(272, angle);
                 }
@@ -210,7 +210,7 @@ void sub_11F88(void)
             }
             else if (gMain.selectedField == FIELD_SPHEAL)
             {
-                if (unk132c->unk10.y < 218)
+                if (unk132c->logicPosition.y < 218)
                 {
                     UPDATE_BALL_POSITION(272, angle);
                 }
@@ -221,7 +221,7 @@ void sub_11F88(void)
             }
             else
             {
-                if (unk132c->unk10.y < 218)
+                if (unk132c->logicPosition.y < 218)
                 {
                     UPDATE_BALL_POSITION(272, angle);
                 }
@@ -241,7 +241,7 @@ void sub_11F88(void)
 
             if (gMain.selectedField <= FIELD_KECLEON)
             {
-                if (unk132c->unk10.y < 150)
+                if (unk132c->logicPosition.y < 150)
                 {
                     UPDATE_BALL_POSITION(304, angle);
                 }
@@ -252,7 +252,7 @@ void sub_11F88(void)
             }
             else if (gMain.selectedField == FIELD_SPHEAL)
             {
-                if (unk132c->unk10.y < 218)
+                if (unk132c->logicPosition.y < 218)
                 {
                     UPDATE_BALL_POSITION(272, angle);
                 }
@@ -263,7 +263,7 @@ void sub_11F88(void)
             }
             else
             {
-                if (unk132c->unk10.y < 218)
+                if (unk132c->logicPosition.y < 218)
                 {
                     UPDATE_BALL_POSITION(304, angle);
                 }
@@ -279,9 +279,9 @@ void sub_11F88(void)
         sub_2AADC();
     }
 
-    unk132c->unk2C = unk132c->unk28;
-    unk132c->unk28.x = (unk132c->position.x + 64) / 128;
-    unk132c->unk28.y = (unk132c->position.y + 64) / 128;
+    unk132c->prevHalfPxPosition = unk132c->halfPxPosition;
+    unk132c->halfPxPosition.x = (unk132c->physicsPosition.x + 64) / 128;
+    unk132c->halfPxPosition.y = (unk132c->physicsPosition.y + 64) / 128;
     unk132c->unk8 = unk132c->unk6;
     unk132c->unkA += unk132c->unk6;
 }
@@ -1369,7 +1369,7 @@ void sub_12BF8()
     struct BallState *unk1334_0;
 
     gCurrentPinballGame->unk1330 = gCurrentPinballGame->unk1334;
-    gCurrentPinballGame->unk132c = gCurrentPinballGame->unk1334;
+    gCurrentPinballGame->pokeball = gCurrentPinballGame->unk1334;
 
     unk1334_0 = &gCurrentPinballGame->unk1334[0];
 
@@ -1397,16 +1397,16 @@ void sub_12BF8()
         break;
     }
 
-    r5 = gCurrentPinballGame->unk132c->unkA >> 12;
+    r5 = gCurrentPinballGame->pokeball->unkA >> 12;
     DmaCopy16(3, &gUnknown_083BB16C[r5 + gCurrentPinballGame->unk5F6 * 17], (void *)VRAM + 0x10400, 0x80);
 
-    unk1334_0->unk10.x = unk1334_0->unk28.x / 2;
-    unk1334_0->unk10.y = unk1334_0->unk28.y / 2;
+    unk1334_0->logicPosition.x = unk1334_0->halfPxPosition.x / 2;
+    unk1334_0->logicPosition.y = unk1334_0->halfPxPosition.y / 2;
 
-    spriteGroup->baseX = unk1334_0->unk10.x
+    spriteGroup->baseX = unk1334_0->logicPosition.x
         - (gCurrentPinballGame->unk4C + 7)
         - gCurrentPinballGame->unk2AA;
-    spriteGroup->baseY = unk1334_0->unk10.y
+    spriteGroup->baseY = unk1334_0->logicPosition.y
         - 7
         - gCurrentPinballGame->unk4E
         - gCurrentPinballGame->unk5FC
@@ -1559,8 +1559,8 @@ void sub_12BF8()
                 gCurrentPinballGame->unkD0[i].x = gCurrentPinballGame->unkD0[i - 1].x;
                 gCurrentPinballGame->unkD0[i].y = gCurrentPinballGame->unkD0[i - 1].y;
             }
-            gCurrentPinballGame->unkD0[0].x = unk1334_0->unk10.x - 7;
-            gCurrentPinballGame->unkD0[0].y = unk1334_0->unk10.y - 7;
+            gCurrentPinballGame->unkD0[0].x = unk1334_0->logicPosition.x - 7;
+            gCurrentPinballGame->unkD0[0].y = unk1334_0->logicPosition.y - 7;
 
             for (i = 0; i < 2; i++)
             {

--- a/src/rom_11B9C.c
+++ b/src/rom_11B9C.c
@@ -20,7 +20,7 @@ void sub_11B9C(void)
     s16 i;
     if (gMain.unk6 == 0)
     {
-        gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[0];
+        gCurrentPinballGame->ball = &gCurrentPinballGame->unk1334[0];
         sub_11C14(0);
         sub_12524();
     }
@@ -28,7 +28,7 @@ void sub_11B9C(void)
     {
         for (i = 0; i < 2; i++)
         {
-            gCurrentPinballGame->pokeball = &gCurrentPinballGame->unk1334[i];
+            gCurrentPinballGame->ball = &gCurrentPinballGame->unk1334[i];
             sub_11C14(i);
         }
         sub_12BF8();
@@ -38,12 +38,12 @@ void sub_11B9C(void)
 void sub_11C14(s16 arg0)
 {
     struct BallState *var0 = &gCurrentPinballGame->unk1334[arg0];
-    var0->logicPosition.x = gUnknown_02031520.unk26;
-    var0->logicPosition.y = gUnknown_02031520.unk28;
-    var0->physicsPosition.x = Q_24_8(var0->logicPosition.x);
-    var0->physicsPosition.y = Q_24_8(var0->logicPosition.y);
-    var0->halfPxPosition.x = gUnknown_02031520.unk26 * 2;
-    var0->halfPxPosition.y = gUnknown_02031520.unk28 * 2;
+    var0->positionQ0.x = gUnknown_02031520.unk26;
+    var0->positionQ0.y = gUnknown_02031520.unk28;
+    var0->positionQ8.x = Q_24_8(var0->positionQ0.x);
+    var0->positionQ8.y = Q_24_8(var0->positionQ0.y);
+    var0->positionQ1.x = gUnknown_02031520.unk26 * 2;
+    var0->positionQ1.y = gUnknown_02031520.unk28 * 2;
     var0->unkE = 0x100;
     var0->velocity.x = 0;
     var0->velocity.y = 0;
@@ -76,8 +76,8 @@ extern const u16 gGravityDeltas_Light[4];
         velocity.x = unk132c->velocity.x;                \
         velocity.y = unk132c->velocity.y;                \
     }                                                    \
-    unk132c->position.x += velocity.x;                   \
-    unk132c->position.y += velocity.y;                   \
+    unk132c->positionQ8.x += velocity.x;                   \
+    unk132c->positionQ8.y += velocity.y;                   \
 }
 
 void sub_11C98(void)
@@ -88,8 +88,8 @@ void sub_11C98(void)
     int squaredMagnitude;
     int maxSpeed;
 
-    unk132c = gCurrentPinballGame->pokeball;
-    unk132c->prevPhysicsPosition = unk132c->physicsPosition;
+    unk132c = gCurrentPinballGame->ball;
+    unk132c->prevPositionQ8 = unk132c->positionQ8;
     if (gCurrentPinballGame->unk5A4 != 2)
     {
         if (gCurrentPinballGame->ballSpeed != 0)
@@ -113,7 +113,7 @@ void sub_11C98(void)
             yy = unk132c->velocity.y * unk132c->velocity.y;
             squaredMagnitude = xx + yy;
 
-            if (unk132c->logicPosition.y < 380)
+            if (unk132c->positionQ0.y < 380)
             {
                 UPDATE_BALL_POSITION(272, angle);
             }
@@ -143,7 +143,7 @@ void sub_11C98(void)
             yy = unk132c->velocity.y * unk132c->velocity.y;
             squaredMagnitude = xx + yy;
 
-            if (unk132c->logicPosition.y < 380)
+            if (unk132c->positionQ0.y < 380)
             {
                 UPDATE_BALL_POSITION(336, angle);
             }
@@ -158,9 +158,9 @@ void sub_11C98(void)
         sub_2AADC();
     }
 
-    unk132c->prevHalfPxPosition = unk132c->halfPxPosition;
-    unk132c->halfPxPosition.x = (unk132c->physicsPosition.x + 64) / 128;
-    unk132c->halfPxPosition.y = (unk132c->physicsPosition.y + 64) / 128;
+    unk132c->prevPositionQ1 = unk132c->positionQ1;
+    unk132c->positionQ1.x = (unk132c->positionQ8.x + 64) / 128;
+    unk132c->positionQ1.y = (unk132c->positionQ8.y + 64) / 128;
     unk132c->unk8 = unk132c->unk6;
     unk132c->unkA += unk132c->unk6;
 }
@@ -173,8 +173,8 @@ void sub_11F88(void)
     int squaredMagnitude;
     int maxSpeed;
 
-    unk132c = gCurrentPinballGame->pokeball;
-    unk132c->prevPhysicsPosition = unk132c->physicsPosition;
+    unk132c = gCurrentPinballGame->ball;
+    unk132c->prevPositionQ8 = unk132c->positionQ8;
     if (gCurrentPinballGame->unk5A4 != 2)
     {
         if (!gCurrentPinballGame->unk1F && !gCurrentPinballGame->unk383)
@@ -199,7 +199,7 @@ void sub_11F88(void)
 
             if (gMain.selectedField <= FIELD_KECLEON)
             {
-                if (unk132c->logicPosition.y < 150)
+                if (unk132c->positionQ0.y < 150)
                 {
                     UPDATE_BALL_POSITION(272, angle);
                 }
@@ -210,7 +210,7 @@ void sub_11F88(void)
             }
             else if (gMain.selectedField == FIELD_SPHEAL)
             {
-                if (unk132c->logicPosition.y < 218)
+                if (unk132c->positionQ0.y < 218)
                 {
                     UPDATE_BALL_POSITION(272, angle);
                 }
@@ -221,7 +221,7 @@ void sub_11F88(void)
             }
             else
             {
-                if (unk132c->logicPosition.y < 218)
+                if (unk132c->positionQ0.y < 218)
                 {
                     UPDATE_BALL_POSITION(272, angle);
                 }
@@ -241,7 +241,7 @@ void sub_11F88(void)
 
             if (gMain.selectedField <= FIELD_KECLEON)
             {
-                if (unk132c->logicPosition.y < 150)
+                if (unk132c->positionQ0.y < 150)
                 {
                     UPDATE_BALL_POSITION(304, angle);
                 }
@@ -252,7 +252,7 @@ void sub_11F88(void)
             }
             else if (gMain.selectedField == FIELD_SPHEAL)
             {
-                if (unk132c->logicPosition.y < 218)
+                if (unk132c->positionQ0.y < 218)
                 {
                     UPDATE_BALL_POSITION(272, angle);
                 }
@@ -263,7 +263,7 @@ void sub_11F88(void)
             }
             else
             {
-                if (unk132c->logicPosition.y < 218)
+                if (unk132c->positionQ0.y < 218)
                 {
                     UPDATE_BALL_POSITION(304, angle);
                 }
@@ -279,9 +279,9 @@ void sub_11F88(void)
         sub_2AADC();
     }
 
-    unk132c->prevHalfPxPosition = unk132c->halfPxPosition;
-    unk132c->halfPxPosition.x = (unk132c->physicsPosition.x + 64) / 128;
-    unk132c->halfPxPosition.y = (unk132c->physicsPosition.y + 64) / 128;
+    unk132c->prevPositionQ1 = unk132c->positionQ1;
+    unk132c->positionQ1.x = (unk132c->positionQ8.x + 64) / 128;
+    unk132c->positionQ1.y = (unk132c->positionQ8.y + 64) / 128;
     unk132c->unk8 = unk132c->unk6;
     unk132c->unkA += unk132c->unk6;
 }
@@ -1369,7 +1369,7 @@ void sub_12BF8()
     struct BallState *unk1334_0;
 
     gCurrentPinballGame->unk1330 = gCurrentPinballGame->unk1334;
-    gCurrentPinballGame->pokeball = gCurrentPinballGame->unk1334;
+    gCurrentPinballGame->ball = gCurrentPinballGame->unk1334;
 
     unk1334_0 = &gCurrentPinballGame->unk1334[0];
 
@@ -1397,16 +1397,16 @@ void sub_12BF8()
         break;
     }
 
-    r5 = gCurrentPinballGame->pokeball->unkA >> 12;
+    r5 = gCurrentPinballGame->ball->unkA >> 12;
     DmaCopy16(3, &gUnknown_083BB16C[r5 + gCurrentPinballGame->unk5F6 * 17], (void *)VRAM + 0x10400, 0x80);
 
-    unk1334_0->logicPosition.x = unk1334_0->halfPxPosition.x / 2;
-    unk1334_0->logicPosition.y = unk1334_0->halfPxPosition.y / 2;
+    unk1334_0->positionQ0.x = unk1334_0->positionQ1.x / 2;
+    unk1334_0->positionQ0.y = unk1334_0->positionQ1.y / 2;
 
-    spriteGroup->baseX = unk1334_0->logicPosition.x
+    spriteGroup->baseX = unk1334_0->positionQ0.x
         - (gCurrentPinballGame->unk4C + 7)
         - gCurrentPinballGame->unk2AA;
-    spriteGroup->baseY = unk1334_0->logicPosition.y
+    spriteGroup->baseY = unk1334_0->positionQ0.y
         - 7
         - gCurrentPinballGame->unk4E
         - gCurrentPinballGame->unk5FC
@@ -1559,8 +1559,8 @@ void sub_12BF8()
                 gCurrentPinballGame->unkD0[i].x = gCurrentPinballGame->unkD0[i - 1].x;
                 gCurrentPinballGame->unkD0[i].y = gCurrentPinballGame->unkD0[i - 1].y;
             }
-            gCurrentPinballGame->unkD0[0].x = unk1334_0->logicPosition.x - 7;
-            gCurrentPinballGame->unkD0[0].y = unk1334_0->logicPosition.y - 7;
+            gCurrentPinballGame->unkD0[0].x = unk1334_0->positionQ0.x - 7;
+            gCurrentPinballGame->unkD0[0].y = unk1334_0->positionQ0.y - 7;
 
             for (i = 0; i < 2; i++)
             {

--- a/src/rom_1332C.c
+++ b/src/rom_1332C.c
@@ -24,12 +24,12 @@ void sub_1333C()
     switch (gCurrentPinballGame->unk22) 
     {
         case 7:
-            gCurrentPinballGame->pokeball->velocity.x = 0;
-            gCurrentPinballGame->pokeball->velocity.y = 0;
+            gCurrentPinballGame->ball->velocity.x = 0;
+            gCurrentPinballGame->ball->velocity.y = 0;
             break;
         case 1:
             sub_13934(&var0, &var1, r7);
-            sub_13D24(r7, &gCurrentPinballGame->pokeball->velocity, &var2);
+            sub_13D24(r7, &gCurrentPinballGame->ball->velocity, &var2);
             for (i = 0; i < 9; i++)
             {
                 if (gUnknown_086ACD50[i].unk2 <= r7) 
@@ -39,18 +39,18 @@ void sub_1333C()
                     break;
                 }
             }
-            gCurrentPinballGame->pokeball->velocity.x = var2.x + var1.x;
-            gCurrentPinballGame->pokeball->velocity.y = var2.y + var1.y;
+            gCurrentPinballGame->ball->velocity.x = var2.x + var1.x;
+            gCurrentPinballGame->ball->velocity.y = var2.y + var1.y;
             break;
         case 6:
             sub_13934(&var0, &var1,r7);
-            sub_13D24(r7, &gCurrentPinballGame->pokeball->velocity, &var2); 
-            gCurrentPinballGame->pokeball->velocity.x = var2.x + var1.x;
-            gCurrentPinballGame->pokeball->velocity.y = var2.y + var1.y;
+            sub_13D24(r7, &gCurrentPinballGame->ball->velocity, &var2); 
+            gCurrentPinballGame->ball->velocity.x = var2.x + var1.x;
+            gCurrentPinballGame->ball->velocity.y = var2.y + var1.y;
             break;
         case 2:
             sub_13934(&var0, &var1, r7);
-            sub_13D24(r7, &gCurrentPinballGame->pokeball->velocity, &var2);
+            sub_13D24(r7, &gCurrentPinballGame->ball->velocity, &var2);
             for (i = 0; i < 9; i++)
             {
                 if (gUnknown_086ACD50[i].unk2 <= r7) 
@@ -60,8 +60,8 @@ void sub_1333C()
                     break;
                 }
             }
-            gCurrentPinballGame->pokeball->velocity.x = var2.x + var1.x;
-            gCurrentPinballGame->pokeball->velocity.y = var2.y + var1.y;
+            gCurrentPinballGame->ball->velocity.x = var2.x + var1.x;
+            gCurrentPinballGame->ball->velocity.y = var2.y + var1.y;
             break;
         case 3:
             sub_13934(&var0, &var1, r7);
@@ -69,17 +69,17 @@ void sub_1333C()
             var0.y -= (gUnknown_02031520.unk20 * 2);
             if (gCurrentPinballGame->unk13BC[0].unk4 == 0)
             {
-                sub_13D24(r7, &gCurrentPinballGame->pokeball->velocity, &var2);
+                sub_13D24(r7, &gCurrentPinballGame->ball->velocity, &var2);
                 gCurrentPinballGame->unk13BC[0].unk4 = 1;
             }
             else
             {            
-                var2.x = gCurrentPinballGame->pokeball->velocity.x;
-                var2.y = gCurrentPinballGame->pokeball->velocity.y;
+                var2.x = gCurrentPinballGame->ball->velocity.x;
+                var2.y = gCurrentPinballGame->ball->velocity.y;
             }
             sub_13B28(&var0, &var2, 0);
-            gCurrentPinballGame->pokeball->velocity.x = var2.x + var1.x;
-            gCurrentPinballGame->pokeball->velocity.y = var2.y + var1.y;
+            gCurrentPinballGame->ball->velocity.x = var2.x + var1.x;
+            gCurrentPinballGame->ball->velocity.y = var2.y + var1.y;
             if (gCurrentPinballGame->unk22 == 5) 
             {
                 for (i = 0; i < 4; i++)
@@ -101,20 +101,20 @@ void sub_1333C()
             var0.y -= (gUnknown_02031520.unk20 * 2);
             if (gCurrentPinballGame->unk13BC[1].unk4 == 0)
             {
-                sub_13D24(r7, &gCurrentPinballGame->pokeball->velocity, &var2);
+                sub_13D24(r7, &gCurrentPinballGame->ball->velocity, &var2);
                 gCurrentPinballGame->unk13BC[1].unk4 = 1;
             }
             else
             {
-                var2.x = gCurrentPinballGame->pokeball->velocity.x;
-                var2.y = gCurrentPinballGame->pokeball->velocity.y;
+                var2.x = gCurrentPinballGame->ball->velocity.x;
+                var2.y = gCurrentPinballGame->ball->velocity.y;
             }
             var0.x = 0x5f - var0.x;
             var2.x = -var2.x;
             sub_13B28(&var0, &var2, 1);
             var2.x = -var2.x;
-            gCurrentPinballGame->pokeball->velocity.x = var2.x + var1.x;
-            gCurrentPinballGame->pokeball->velocity.y = var2.y + var1.y;
+            gCurrentPinballGame->ball->velocity.x = var2.x + var1.x;
+            gCurrentPinballGame->ball->velocity.y = var2.y + var1.y;
             if (gCurrentPinballGame->unk22 == 5) 
             {
                 for (i = 0; i < 4; i++)
@@ -136,7 +136,7 @@ void sub_1333C()
             {
                 if (gCurrentPinballGame->unk127 != 1)
                 {
-                    gCurrentPinballGame->pokeball->velocity.x -=  4;
+                    gCurrentPinballGame->ball->velocity.x -=  4;
                     gCurrentPinballGame->unk127 = 1;
                 }
             }
@@ -144,7 +144,7 @@ void sub_1333C()
             {
                 if (gCurrentPinballGame->unk127 != -1)
                 {
-                    gCurrentPinballGame->pokeball->velocity.x += 4;
+                    gCurrentPinballGame->ball->velocity.x += 4;
                     gCurrentPinballGame->unk127 = -1;
                 }
             }
@@ -155,10 +155,10 @@ void sub_1333C()
     }
     if (gCurrentPinballGame->unk22 != 0) 
     {
-        gCurrentPinballGame->pokeball->halfPxPosition.x = var0.x;
-        gCurrentPinballGame->pokeball->halfPxPosition.y = var0.y;
-        gCurrentPinballGame->pokeball->physicsPosition.x = gCurrentPinballGame->pokeball->halfPxPosition.x << 7;
-        gCurrentPinballGame->pokeball->physicsPosition.y = gCurrentPinballGame->pokeball->halfPxPosition.y << 7;
+        gCurrentPinballGame->ball->positionQ1.x = var0.x;
+        gCurrentPinballGame->ball->positionQ1.y = var0.y;
+        gCurrentPinballGame->ball->positionQ8.x = gCurrentPinballGame->ball->positionQ1.x << 7;
+        gCurrentPinballGame->ball->positionQ8.y = gCurrentPinballGame->ball->positionQ1.y << 7;
     }
 }
 
@@ -166,10 +166,10 @@ u16 sub_13824(struct Vector16* param)
 {
     u16 retVal;
     struct Vector16 test;
-    test.x = gCurrentPinballGame->pokeball->halfPxPosition.x - gCurrentPinballGame->pokeball->prevHalfPxPosition.x;
-    test.y = gCurrentPinballGame->pokeball->halfPxPosition.y - gCurrentPinballGame->pokeball->prevHalfPxPosition.y;
-    param->x = gCurrentPinballGame->pokeball->prevHalfPxPosition.x;
-    param->y = gCurrentPinballGame->pokeball->prevHalfPxPosition.y;
+    test.x = gCurrentPinballGame->ball->positionQ1.x - gCurrentPinballGame->ball->prevPositionQ1.x;
+    test.y = gCurrentPinballGame->ball->positionQ1.y - gCurrentPinballGame->ball->prevPositionQ1.y;
+    param->x = gCurrentPinballGame->ball->prevPositionQ1.x;
+    param->y = gCurrentPinballGame->ball->prevPositionQ1.y;
     retVal = sub_14488(param, test);
 
     gCurrentPinballGame->unk124 = 0;
@@ -177,13 +177,13 @@ u16 sub_13824(struct Vector16* param)
 
     if (!gCurrentPinballGame->unk22 && (gCurrentPinballGame->unk122 || gCurrentPinballGame->unk123))
     {
-        param->x = gCurrentPinballGame->pokeball->halfPxPosition.x;
-        param->y = gCurrentPinballGame->pokeball->halfPxPosition.y;
+        param->x = gCurrentPinballGame->ball->positionQ1.x;
+        param->y = gCurrentPinballGame->ball->positionQ1.y;
         test.x = gCurrentPinballGame->unk122;
         test.y = gCurrentPinballGame->unk123;
         retVal = sub_14488(param, test);
-        gCurrentPinballGame->unk124 = param->x - gCurrentPinballGame->pokeball->halfPxPosition.x;
-        gCurrentPinballGame->unk125 = param->y - gCurrentPinballGame->pokeball->halfPxPosition.y;
+        gCurrentPinballGame->unk124 = param->x - gCurrentPinballGame->ball->positionQ1.x;
+        gCurrentPinballGame->unk125 = param->y - gCurrentPinballGame->ball->positionQ1.y;
     }
     return retVal;
 }
@@ -220,7 +220,7 @@ void sub_13934(struct Vector16 *arg0, struct Vector16 *arg1, u16 angle)
     if (gCurrentPinballGame->unk123 > 0)
     {
         arg0->y -= gCurrentPinballGame->unk125;
-        if (gCurrentPinballGame->pokeball->logicPosition.y > 364)
+        if (gCurrentPinballGame->ball->positionQ0.y > 364)
         {
             if (gCurrentPinballGame->unk122 == 0)
                 arg1->y = -(Sin(angle) * 130) / 20000;
@@ -235,9 +235,9 @@ void sub_13934(struct Vector16 *arg0, struct Vector16 *arg1, u16 angle)
                 arg1->y = -(Sin(angle) * 75) / 20000;
 
             if (arg1->y >= 90)
-                gCurrentPinballGame->pokeball->velocity.x /= 4;
+                gCurrentPinballGame->ball->velocity.x /= 4;
             else if (arg1->y >= 70)
-                gCurrentPinballGame->pokeball->velocity.x /= 4;
+                gCurrentPinballGame->ball->velocity.x /= 4;
         }
 
         gCurrentPinballGame->unk126 = 1;

--- a/src/rom_1332C.c
+++ b/src/rom_1332C.c
@@ -24,12 +24,12 @@ void sub_1333C()
     switch (gCurrentPinballGame->unk22) 
     {
         case 7:
-            gCurrentPinballGame->unk132c->velocity.x = 0;
-            gCurrentPinballGame->unk132c->velocity.y = 0;
+            gCurrentPinballGame->pokeball->velocity.x = 0;
+            gCurrentPinballGame->pokeball->velocity.y = 0;
             break;
         case 1:
             sub_13934(&var0, &var1, r7);
-            sub_13D24(r7, &gCurrentPinballGame->unk132c->velocity, &var2);
+            sub_13D24(r7, &gCurrentPinballGame->pokeball->velocity, &var2);
             for (i = 0; i < 9; i++)
             {
                 if (gUnknown_086ACD50[i].unk2 <= r7) 
@@ -39,18 +39,18 @@ void sub_1333C()
                     break;
                 }
             }
-            gCurrentPinballGame->unk132c->velocity.x = var2.x + var1.x;
-            gCurrentPinballGame->unk132c->velocity.y = var2.y + var1.y;
+            gCurrentPinballGame->pokeball->velocity.x = var2.x + var1.x;
+            gCurrentPinballGame->pokeball->velocity.y = var2.y + var1.y;
             break;
         case 6:
             sub_13934(&var0, &var1,r7);
-            sub_13D24(r7, &gCurrentPinballGame->unk132c->velocity, &var2); 
-            gCurrentPinballGame->unk132c->velocity.x = var2.x + var1.x;
-            gCurrentPinballGame->unk132c->velocity.y = var2.y + var1.y;
+            sub_13D24(r7, &gCurrentPinballGame->pokeball->velocity, &var2); 
+            gCurrentPinballGame->pokeball->velocity.x = var2.x + var1.x;
+            gCurrentPinballGame->pokeball->velocity.y = var2.y + var1.y;
             break;
         case 2:
             sub_13934(&var0, &var1, r7);
-            sub_13D24(r7, &gCurrentPinballGame->unk132c->velocity, &var2);
+            sub_13D24(r7, &gCurrentPinballGame->pokeball->velocity, &var2);
             for (i = 0; i < 9; i++)
             {
                 if (gUnknown_086ACD50[i].unk2 <= r7) 
@@ -60,8 +60,8 @@ void sub_1333C()
                     break;
                 }
             }
-            gCurrentPinballGame->unk132c->velocity.x = var2.x + var1.x;
-            gCurrentPinballGame->unk132c->velocity.y = var2.y + var1.y;
+            gCurrentPinballGame->pokeball->velocity.x = var2.x + var1.x;
+            gCurrentPinballGame->pokeball->velocity.y = var2.y + var1.y;
             break;
         case 3:
             sub_13934(&var0, &var1, r7);
@@ -69,17 +69,17 @@ void sub_1333C()
             var0.y -= (gUnknown_02031520.unk20 * 2);
             if (gCurrentPinballGame->unk13BC[0].unk4 == 0)
             {
-                sub_13D24(r7, &gCurrentPinballGame->unk132c->velocity, &var2);
+                sub_13D24(r7, &gCurrentPinballGame->pokeball->velocity, &var2);
                 gCurrentPinballGame->unk13BC[0].unk4 = 1;
             }
             else
             {            
-                var2.x = gCurrentPinballGame->unk132c->velocity.x;
-                var2.y = gCurrentPinballGame->unk132c->velocity.y;
+                var2.x = gCurrentPinballGame->pokeball->velocity.x;
+                var2.y = gCurrentPinballGame->pokeball->velocity.y;
             }
             sub_13B28(&var0, &var2, 0);
-            gCurrentPinballGame->unk132c->velocity.x = var2.x + var1.x;
-            gCurrentPinballGame->unk132c->velocity.y = var2.y + var1.y;
+            gCurrentPinballGame->pokeball->velocity.x = var2.x + var1.x;
+            gCurrentPinballGame->pokeball->velocity.y = var2.y + var1.y;
             if (gCurrentPinballGame->unk22 == 5) 
             {
                 for (i = 0; i < 4; i++)
@@ -101,20 +101,20 @@ void sub_1333C()
             var0.y -= (gUnknown_02031520.unk20 * 2);
             if (gCurrentPinballGame->unk13BC[1].unk4 == 0)
             {
-                sub_13D24(r7, &gCurrentPinballGame->unk132c->velocity, &var2);
+                sub_13D24(r7, &gCurrentPinballGame->pokeball->velocity, &var2);
                 gCurrentPinballGame->unk13BC[1].unk4 = 1;
             }
             else
             {
-                var2.x = gCurrentPinballGame->unk132c->velocity.x;
-                var2.y = gCurrentPinballGame->unk132c->velocity.y;
+                var2.x = gCurrentPinballGame->pokeball->velocity.x;
+                var2.y = gCurrentPinballGame->pokeball->velocity.y;
             }
             var0.x = 0x5f - var0.x;
             var2.x = -var2.x;
             sub_13B28(&var0, &var2, 1);
             var2.x = -var2.x;
-            gCurrentPinballGame->unk132c->velocity.x = var2.x + var1.x;
-            gCurrentPinballGame->unk132c->velocity.y = var2.y + var1.y;
+            gCurrentPinballGame->pokeball->velocity.x = var2.x + var1.x;
+            gCurrentPinballGame->pokeball->velocity.y = var2.y + var1.y;
             if (gCurrentPinballGame->unk22 == 5) 
             {
                 for (i = 0; i < 4; i++)
@@ -136,7 +136,7 @@ void sub_1333C()
             {
                 if (gCurrentPinballGame->unk127 != 1)
                 {
-                    gCurrentPinballGame->unk132c->velocity.x -=  4;
+                    gCurrentPinballGame->pokeball->velocity.x -=  4;
                     gCurrentPinballGame->unk127 = 1;
                 }
             }
@@ -144,7 +144,7 @@ void sub_1333C()
             {
                 if (gCurrentPinballGame->unk127 != -1)
                 {
-                    gCurrentPinballGame->unk132c->velocity.x += 4;
+                    gCurrentPinballGame->pokeball->velocity.x += 4;
                     gCurrentPinballGame->unk127 = -1;
                 }
             }
@@ -155,10 +155,10 @@ void sub_1333C()
     }
     if (gCurrentPinballGame->unk22 != 0) 
     {
-        gCurrentPinballGame->unk132c->unk28.x = var0.x;
-        gCurrentPinballGame->unk132c->unk28.y = var0.y;
-        gCurrentPinballGame->unk132c->position.x = gCurrentPinballGame->unk132c->unk28.x << 7;
-        gCurrentPinballGame->unk132c->position.y = gCurrentPinballGame->unk132c->unk28.y << 7;
+        gCurrentPinballGame->pokeball->halfPxPosition.x = var0.x;
+        gCurrentPinballGame->pokeball->halfPxPosition.y = var0.y;
+        gCurrentPinballGame->pokeball->physicsPosition.x = gCurrentPinballGame->pokeball->halfPxPosition.x << 7;
+        gCurrentPinballGame->pokeball->physicsPosition.y = gCurrentPinballGame->pokeball->halfPxPosition.y << 7;
     }
 }
 
@@ -166,10 +166,10 @@ u16 sub_13824(struct Vector16* param)
 {
     u16 retVal;
     struct Vector16 test;
-    test.x = gCurrentPinballGame->unk132c->unk28.x - gCurrentPinballGame->unk132c->unk2C.x;
-    test.y = gCurrentPinballGame->unk132c->unk28.y - gCurrentPinballGame->unk132c->unk2C.y;
-    param->x = gCurrentPinballGame->unk132c->unk2C.x;
-    param->y = gCurrentPinballGame->unk132c->unk2C.y;
+    test.x = gCurrentPinballGame->pokeball->halfPxPosition.x - gCurrentPinballGame->pokeball->prevHalfPxPosition.x;
+    test.y = gCurrentPinballGame->pokeball->halfPxPosition.y - gCurrentPinballGame->pokeball->prevHalfPxPosition.y;
+    param->x = gCurrentPinballGame->pokeball->prevHalfPxPosition.x;
+    param->y = gCurrentPinballGame->pokeball->prevHalfPxPosition.y;
     retVal = sub_14488(param, test);
 
     gCurrentPinballGame->unk124 = 0;
@@ -177,13 +177,13 @@ u16 sub_13824(struct Vector16* param)
 
     if (!gCurrentPinballGame->unk22 && (gCurrentPinballGame->unk122 || gCurrentPinballGame->unk123))
     {
-        param->x = gCurrentPinballGame->unk132c->unk28.x;
-        param->y = gCurrentPinballGame->unk132c->unk28.y;
+        param->x = gCurrentPinballGame->pokeball->halfPxPosition.x;
+        param->y = gCurrentPinballGame->pokeball->halfPxPosition.y;
         test.x = gCurrentPinballGame->unk122;
         test.y = gCurrentPinballGame->unk123;
         retVal = sub_14488(param, test);
-        gCurrentPinballGame->unk124 = param->x - gCurrentPinballGame->unk132c->unk28.x;
-        gCurrentPinballGame->unk125 = param->y - gCurrentPinballGame->unk132c->unk28.y;
+        gCurrentPinballGame->unk124 = param->x - gCurrentPinballGame->pokeball->halfPxPosition.x;
+        gCurrentPinballGame->unk125 = param->y - gCurrentPinballGame->pokeball->halfPxPosition.y;
     }
     return retVal;
 }
@@ -220,7 +220,7 @@ void sub_13934(struct Vector16 *arg0, struct Vector16 *arg1, u16 angle)
     if (gCurrentPinballGame->unk123 > 0)
     {
         arg0->y -= gCurrentPinballGame->unk125;
-        if (gCurrentPinballGame->unk132c->unk10.y > 364)
+        if (gCurrentPinballGame->pokeball->logicPosition.y > 364)
         {
             if (gCurrentPinballGame->unk122 == 0)
                 arg1->y = -(Sin(angle) * 130) / 20000;
@@ -235,9 +235,9 @@ void sub_13934(struct Vector16 *arg0, struct Vector16 *arg1, u16 angle)
                 arg1->y = -(Sin(angle) * 75) / 20000;
 
             if (arg1->y >= 90)
-                gCurrentPinballGame->unk132c->velocity.x /= 4;
+                gCurrentPinballGame->pokeball->velocity.x /= 4;
             else if (arg1->y >= 70)
-                gCurrentPinballGame->unk132c->velocity.x /= 4;
+                gCurrentPinballGame->pokeball->velocity.x /= 4;
         }
 
         gCurrentPinballGame->unk126 = 1;

--- a/src/rom_18784.c
+++ b/src/rom_18784.c
@@ -42,7 +42,7 @@ s16 sub_187F4(struct Vector16 *arg0, u16 *arg1)
     u32 switch_enum;
 
     return_val = 0;
-    gCurrentPinballGame->pokeball->unk4 = 0;
+    gCurrentPinballGame->ball->unk4 = 0;
 
     if (arg0->y < 0x200)
     {
@@ -80,13 +80,13 @@ s16 sub_187F4(struct Vector16 *arg0, u16 *arg1)
         *arg1 = sp00;
         if (*arg1 >= 0x3FF0 && *arg1 <= 0x4010)
         {
-            if (gCurrentPinballGame->pokeball->logicPosition.x < (gUnknown_02031520.unk26 - 8) || gCurrentPinballGame->pokeball->logicPosition.y < gUnknown_02031520.unk28 - 8)
+            if (gCurrentPinballGame->ball->positionQ0.x < (gUnknown_02031520.unk26 - 8) || gCurrentPinballGame->ball->positionQ0.y < gUnknown_02031520.unk28 - 8)
             {
-                if (gCurrentPinballGame->pokeball->unk6 > 0)
+                if (gCurrentPinballGame->ball->unk6 > 0)
                 {
                     *arg1 = 0x3E00;
                 }
-                else if (gCurrentPinballGame->pokeball->unk6 != 0)
+                else if (gCurrentPinballGame->ball->unk6 != 0)
                 {
                     *arg1 = 0x4100;
                 }
@@ -94,14 +94,14 @@ s16 sub_187F4(struct Vector16 *arg0, u16 *arg1)
                 {
                     if (gMain.systemFrameCount & 1)
                     {
-                        gCurrentPinballGame->pokeball->unk4 = 40;
-                        gCurrentPinballGame->pokeball->unk6 = 1;
+                        gCurrentPinballGame->ball->unk4 = 40;
+                        gCurrentPinballGame->ball->unk6 = 1;
                         *arg1 = 0x3E00;
                     }
                     else
                     {
-                        gCurrentPinballGame->pokeball->unk4 = -40;
-                        gCurrentPinballGame->pokeball->unk6 = -1;
+                        gCurrentPinballGame->ball->unk4 = -40;
+                        gCurrentPinballGame->ball->unk6 = -1;
                         *arg1 = 0x4100;
                     }
                 }
@@ -196,7 +196,7 @@ s16 sub_18B50(struct Vector16 *arg0, u16 *arg1)
     u8 enum1, enum2;
 
     sp4_return = 0;
-    gCurrentPinballGame->pokeball->unk4 = 0;
+    gCurrentPinballGame->ball->unk4 = 0;
 
     div_result.x = arg0->x / 8;
     div_result.y = arg0->y / 8;
@@ -224,14 +224,14 @@ s16 sub_18B50(struct Vector16 *arg0, u16 *arg1)
         *arg1 = sp0;
         if (*arg1 >= 0x3FF0 && *arg1 <= 0x4010)
         {
-            if (gCurrentPinballGame->pokeball->logicPosition.x < (gUnknown_02031520.unk26 - 8) ||
-                gCurrentPinballGame->pokeball->logicPosition.y < (gUnknown_02031520.unk28 - 8))
+            if (gCurrentPinballGame->ball->positionQ0.x < (gUnknown_02031520.unk26 - 8) ||
+                gCurrentPinballGame->ball->positionQ0.y < (gUnknown_02031520.unk28 - 8))
             {
-                if (gCurrentPinballGame->pokeball->unk6 > 0)
+                if (gCurrentPinballGame->ball->unk6 > 0)
                 {
                     *arg1 = 0x3E00;
                 }
-                else if (gCurrentPinballGame->pokeball->unk6 != 0)
+                else if (gCurrentPinballGame->ball->unk6 != 0)
                 {
                     *arg1 = 0x4100;
                 }
@@ -239,14 +239,14 @@ s16 sub_18B50(struct Vector16 *arg0, u16 *arg1)
                 {
                     if (gMain.systemFrameCount & 1)
                     {
-                        gCurrentPinballGame->pokeball->unk4 = 40;
-                        gCurrentPinballGame->pokeball->unk6 = 1;
+                        gCurrentPinballGame->ball->unk4 = 40;
+                        gCurrentPinballGame->ball->unk6 = 1;
                         *arg1 = 0x3E00;
                     }
                     else
                     {
-                        gCurrentPinballGame->pokeball->unk4 = -40;
-                        gCurrentPinballGame->pokeball->unk6 = -1;
+                        gCurrentPinballGame->ball->unk4 = -40;
+                        gCurrentPinballGame->ball->unk6 = -1;
                         *arg1 = 0x4100;
                     }
                 }
@@ -260,7 +260,7 @@ s16 sub_18B50(struct Vector16 *arg0, u16 *arg1)
         gCurrentPinballGame->unk22 = 1;
         *arg1 = sp0 & 0x0000FFF0;
 
-        if (gCurrentPinballGame->pokeball->logicPosition.x < 120)
+        if (gCurrentPinballGame->ball->positionQ0.x < 120)
             gCurrentPinballGame->unk548 = 24;
         else
             gCurrentPinballGame->unk549 = 24;

--- a/src/rom_18784.c
+++ b/src/rom_18784.c
@@ -42,7 +42,7 @@ s16 sub_187F4(struct Vector16 *arg0, u16 *arg1)
     u32 switch_enum;
 
     return_val = 0;
-    gCurrentPinballGame->unk132c->unk4 = 0;
+    gCurrentPinballGame->pokeball->unk4 = 0;
 
     if (arg0->y < 0x200)
     {
@@ -80,13 +80,13 @@ s16 sub_187F4(struct Vector16 *arg0, u16 *arg1)
         *arg1 = sp00;
         if (*arg1 >= 0x3FF0 && *arg1 <= 0x4010)
         {
-            if (gCurrentPinballGame->unk132c->unk10.x < (gUnknown_02031520.unk26 - 8) || gCurrentPinballGame->unk132c->unk10.y < gUnknown_02031520.unk28 - 8)
+            if (gCurrentPinballGame->pokeball->logicPosition.x < (gUnknown_02031520.unk26 - 8) || gCurrentPinballGame->pokeball->logicPosition.y < gUnknown_02031520.unk28 - 8)
             {
-                if (gCurrentPinballGame->unk132c->unk6 > 0)
+                if (gCurrentPinballGame->pokeball->unk6 > 0)
                 {
                     *arg1 = 0x3E00;
                 }
-                else if (gCurrentPinballGame->unk132c->unk6 != 0)
+                else if (gCurrentPinballGame->pokeball->unk6 != 0)
                 {
                     *arg1 = 0x4100;
                 }
@@ -94,14 +94,14 @@ s16 sub_187F4(struct Vector16 *arg0, u16 *arg1)
                 {
                     if (gMain.systemFrameCount & 1)
                     {
-                        gCurrentPinballGame->unk132c->unk4 = 40;
-                        gCurrentPinballGame->unk132c->unk6 = 1;
+                        gCurrentPinballGame->pokeball->unk4 = 40;
+                        gCurrentPinballGame->pokeball->unk6 = 1;
                         *arg1 = 0x3E00;
                     }
                     else
                     {
-                        gCurrentPinballGame->unk132c->unk4 = -40;
-                        gCurrentPinballGame->unk132c->unk6 = -1;
+                        gCurrentPinballGame->pokeball->unk4 = -40;
+                        gCurrentPinballGame->pokeball->unk6 = -1;
                         *arg1 = 0x4100;
                     }
                 }
@@ -196,7 +196,7 @@ s16 sub_18B50(struct Vector16 *arg0, u16 *arg1)
     u8 enum1, enum2;
 
     sp4_return = 0;
-    gCurrentPinballGame->unk132c->unk4 = 0;
+    gCurrentPinballGame->pokeball->unk4 = 0;
 
     div_result.x = arg0->x / 8;
     div_result.y = arg0->y / 8;
@@ -224,14 +224,14 @@ s16 sub_18B50(struct Vector16 *arg0, u16 *arg1)
         *arg1 = sp0;
         if (*arg1 >= 0x3FF0 && *arg1 <= 0x4010)
         {
-            if (gCurrentPinballGame->unk132c->unk10.x < (gUnknown_02031520.unk26 - 8) ||
-                gCurrentPinballGame->unk132c->unk10.y < (gUnknown_02031520.unk28 - 8))
+            if (gCurrentPinballGame->pokeball->logicPosition.x < (gUnknown_02031520.unk26 - 8) ||
+                gCurrentPinballGame->pokeball->logicPosition.y < (gUnknown_02031520.unk28 - 8))
             {
-                if (gCurrentPinballGame->unk132c->unk6 > 0)
+                if (gCurrentPinballGame->pokeball->unk6 > 0)
                 {
                     *arg1 = 0x3E00;
                 }
-                else if (gCurrentPinballGame->unk132c->unk6 != 0)
+                else if (gCurrentPinballGame->pokeball->unk6 != 0)
                 {
                     *arg1 = 0x4100;
                 }
@@ -239,14 +239,14 @@ s16 sub_18B50(struct Vector16 *arg0, u16 *arg1)
                 {
                     if (gMain.systemFrameCount & 1)
                     {
-                        gCurrentPinballGame->unk132c->unk4 = 40;
-                        gCurrentPinballGame->unk132c->unk6 = 1;
+                        gCurrentPinballGame->pokeball->unk4 = 40;
+                        gCurrentPinballGame->pokeball->unk6 = 1;
                         *arg1 = 0x3E00;
                     }
                     else
                     {
-                        gCurrentPinballGame->unk132c->unk4 = -40;
-                        gCurrentPinballGame->unk132c->unk6 = -1;
+                        gCurrentPinballGame->pokeball->unk4 = -40;
+                        gCurrentPinballGame->pokeball->unk6 = -1;
                         *arg1 = 0x4100;
                     }
                 }
@@ -260,7 +260,7 @@ s16 sub_18B50(struct Vector16 *arg0, u16 *arg1)
         gCurrentPinballGame->unk22 = 1;
         *arg1 = sp0 & 0x0000FFF0;
 
-        if (gCurrentPinballGame->unk132c->unk10.x < 120)
+        if (gCurrentPinballGame->pokeball->logicPosition.x < 120)
             gCurrentPinballGame->unk548 = 24;
         else
             gCurrentPinballGame->unk549 = 24;

--- a/src/rom_1A98C.c
+++ b/src/rom_1A98C.c
@@ -98,9 +98,9 @@ void sub_1AAA0(void)
             gCurrentPinballGame->unk5F7 = 1;
             gCurrentPinballGame->unk1F = 1;
     
-            gCurrentPinballGame->unk132c->velocity.x = 0;
-            gCurrentPinballGame->unk132c->velocity.y = 0;
-            gCurrentPinballGame->unk132c->unk6 = 0;
+            gCurrentPinballGame->pokeball->velocity.x = 0;
+            gCurrentPinballGame->pokeball->velocity.y = 0;
+            gCurrentPinballGame->pokeball->unk6 = 0;
 
             if (gCurrentPinballGame->unk28 > 108)
             {
@@ -108,13 +108,13 @@ void sub_1AAA0(void)
                 
                 if (gCurrentPinballGame->unk28 > 110)
                 {
-                    gCurrentPinballGame->unk132c->unk10.x = 195;
-                    gCurrentPinballGame->unk132c->unk10.y = 222;
+                    gCurrentPinballGame->pokeball->logicPosition.x = 195;
+                    gCurrentPinballGame->pokeball->logicPosition.y = 222;
                 }
                 else
                 {
-                    gCurrentPinballGame->unk132c->unk10.x = 196;
-                    gCurrentPinballGame->unk132c->unk10.y = 221;
+                    gCurrentPinballGame->pokeball->logicPosition.x = 196;
+                    gCurrentPinballGame->pokeball->logicPosition.y = 221;
                 }
                 //Presumed controling either the message board 'state'/'tile'
                 // or the sharpedo animation 'state'/tile.
@@ -122,13 +122,13 @@ void sub_1AAA0(void)
             }
             else if (gCurrentPinballGame->unk28 > 104)
             {
-                gCurrentPinballGame->unk132c->unk10.x = 197;
-                gCurrentPinballGame->unk132c->unk10.y = 219;
+                gCurrentPinballGame->pokeball->logicPosition.x = 197;
+                gCurrentPinballGame->pokeball->logicPosition.y = 219;
                 gCurrentPinballGame->unk2F4 = 7;
             }
             else 
             {
-                gCurrentPinballGame->unk132c->unk0 = 1;
+                gCurrentPinballGame->pokeball->unk0 = 1;
                 gCurrentPinballGame->unk2F4 = 8;
             }
         }
@@ -177,9 +177,9 @@ void sub_1AAA0(void)
         }
         else if (gCurrentPinballGame->unk28 > 18) 
         {
-            gCurrentPinballGame->unk132c->unk10.x = 193;
-            gCurrentPinballGame->unk132c->unk10.y = 226;
-            gCurrentPinballGame->unk132c->unk0 = 0;
+            gCurrentPinballGame->pokeball->logicPosition.x = 193;
+            gCurrentPinballGame->pokeball->logicPosition.y = 226;
+            gCurrentPinballGame->pokeball->unk0 = 0;
             gCurrentPinballGame->unk2F4 = 17;
         }
         else if (gCurrentPinballGame->unk28 > 16) 
@@ -188,11 +188,11 @@ void sub_1AAA0(void)
             gCurrentPinballGame->unk5FE = 0;
             gCurrentPinballGame->unk5FB = 1;
             gCurrentPinballGame->unk5FA = 0;
-            gCurrentPinballGame->unk132c->unk6 = 0;
-            gCurrentPinballGame->unk132c->velocity.x = 0xFF56;
-            gCurrentPinballGame->unk132c->velocity.y = 220;
-            gCurrentPinballGame->unk132c->unk10.x = 190;
-            gCurrentPinballGame->unk132c->unk10.y = 232;
+            gCurrentPinballGame->pokeball->unk6 = 0;
+            gCurrentPinballGame->pokeball->velocity.x = 0xFF56;
+            gCurrentPinballGame->pokeball->velocity.y = 220;
+            gCurrentPinballGame->pokeball->logicPosition.x = 190;
+            gCurrentPinballGame->pokeball->logicPosition.y = 232;
             gCurrentPinballGame->unk2F4 = 18;
             if (gCurrentPinballGame->unk28 == 18)
             {
@@ -202,36 +202,36 @@ void sub_1AAA0(void)
         }
         else if (gCurrentPinballGame->unk28 > 12) 
         {
-            gCurrentPinballGame->unk132c->unk6 = 0;
+            gCurrentPinballGame->pokeball->unk6 = 0;
             gCurrentPinballGame->unk2F4 = 19;
         }
         else if (gCurrentPinballGame->unk28 > 8) 
         {
-            gCurrentPinballGame->unk132c->unk6 = 0;
+            gCurrentPinballGame->pokeball->unk6 = 0;
             gCurrentPinballGame->unk2F4 = 20;
         }
         else if (gCurrentPinballGame->unk28 > 4) 
         {
-            gCurrentPinballGame->unk132c->unk6 = 0;
+            gCurrentPinballGame->pokeball->unk6 = 0;
             gCurrentPinballGame->unk2F4 = 21;
         }
         else
         {
             gCurrentPinballGame->unk2F4 = 22;
         }
-        gCurrentPinballGame->unk132c->unk28.x = gCurrentPinballGame->unk132c->unk10.x * 2;
-        gCurrentPinballGame->unk132c->unk28.y = gCurrentPinballGame->unk132c->unk10.y * 2;
+        gCurrentPinballGame->pokeball->halfPxPosition.x = gCurrentPinballGame->pokeball->logicPosition.x * 2;
+        gCurrentPinballGame->pokeball->halfPxPosition.y = gCurrentPinballGame->pokeball->logicPosition.y * 2;
 
-        gCurrentPinballGame->unk132c->unk2C = gCurrentPinballGame->unk132c->unk28;
-        gCurrentPinballGame->unk132c->position.x= gCurrentPinballGame->unk132c->unk10.x << 8;
-        gCurrentPinballGame->unk132c->position.y = gCurrentPinballGame->unk132c->unk10.y << 8;
+        gCurrentPinballGame->pokeball->prevHalfPxPosition = gCurrentPinballGame->pokeball->halfPxPosition;
+        gCurrentPinballGame->pokeball->physicsPosition.x= gCurrentPinballGame->pokeball->logicPosition.x << 8;
+        gCurrentPinballGame->pokeball->physicsPosition.y = gCurrentPinballGame->pokeball->logicPosition.y << 8;
         
     }
     else
     {
         gCurrentPinballGame->unk26 = 30;
-        gCurrentPinballGame->unk132c->unk28.x = gCurrentPinballGame->unk132c->unk10.x * 2;
-        gCurrentPinballGame->unk132c->unk28.y = gCurrentPinballGame->unk132c->unk10.y * 2;
+        gCurrentPinballGame->pokeball->halfPxPosition.x = gCurrentPinballGame->pokeball->logicPosition.x * 2;
+        gCurrentPinballGame->pokeball->halfPxPosition.y = gCurrentPinballGame->pokeball->logicPosition.y * 2;
         gCurrentPinballGame->unk25 = 0;
         gCurrentPinballGame->unk5F7 = 0;
         gCurrentPinballGame->unk2F4 = 0;

--- a/src/rom_1A98C.c
+++ b/src/rom_1A98C.c
@@ -98,9 +98,9 @@ void sub_1AAA0(void)
             gCurrentPinballGame->unk5F7 = 1;
             gCurrentPinballGame->unk1F = 1;
     
-            gCurrentPinballGame->pokeball->velocity.x = 0;
-            gCurrentPinballGame->pokeball->velocity.y = 0;
-            gCurrentPinballGame->pokeball->unk6 = 0;
+            gCurrentPinballGame->ball->velocity.x = 0;
+            gCurrentPinballGame->ball->velocity.y = 0;
+            gCurrentPinballGame->ball->unk6 = 0;
 
             if (gCurrentPinballGame->unk28 > 108)
             {
@@ -108,13 +108,13 @@ void sub_1AAA0(void)
                 
                 if (gCurrentPinballGame->unk28 > 110)
                 {
-                    gCurrentPinballGame->pokeball->logicPosition.x = 195;
-                    gCurrentPinballGame->pokeball->logicPosition.y = 222;
+                    gCurrentPinballGame->ball->positionQ0.x = 195;
+                    gCurrentPinballGame->ball->positionQ0.y = 222;
                 }
                 else
                 {
-                    gCurrentPinballGame->pokeball->logicPosition.x = 196;
-                    gCurrentPinballGame->pokeball->logicPosition.y = 221;
+                    gCurrentPinballGame->ball->positionQ0.x = 196;
+                    gCurrentPinballGame->ball->positionQ0.y = 221;
                 }
                 //Presumed controling either the message board 'state'/'tile'
                 // or the sharpedo animation 'state'/tile.
@@ -122,13 +122,13 @@ void sub_1AAA0(void)
             }
             else if (gCurrentPinballGame->unk28 > 104)
             {
-                gCurrentPinballGame->pokeball->logicPosition.x = 197;
-                gCurrentPinballGame->pokeball->logicPosition.y = 219;
+                gCurrentPinballGame->ball->positionQ0.x = 197;
+                gCurrentPinballGame->ball->positionQ0.y = 219;
                 gCurrentPinballGame->unk2F4 = 7;
             }
             else 
             {
-                gCurrentPinballGame->pokeball->unk0 = 1;
+                gCurrentPinballGame->ball->unk0 = 1;
                 gCurrentPinballGame->unk2F4 = 8;
             }
         }
@@ -177,9 +177,9 @@ void sub_1AAA0(void)
         }
         else if (gCurrentPinballGame->unk28 > 18) 
         {
-            gCurrentPinballGame->pokeball->logicPosition.x = 193;
-            gCurrentPinballGame->pokeball->logicPosition.y = 226;
-            gCurrentPinballGame->pokeball->unk0 = 0;
+            gCurrentPinballGame->ball->positionQ0.x = 193;
+            gCurrentPinballGame->ball->positionQ0.y = 226;
+            gCurrentPinballGame->ball->unk0 = 0;
             gCurrentPinballGame->unk2F4 = 17;
         }
         else if (gCurrentPinballGame->unk28 > 16) 
@@ -188,11 +188,11 @@ void sub_1AAA0(void)
             gCurrentPinballGame->unk5FE = 0;
             gCurrentPinballGame->unk5FB = 1;
             gCurrentPinballGame->unk5FA = 0;
-            gCurrentPinballGame->pokeball->unk6 = 0;
-            gCurrentPinballGame->pokeball->velocity.x = 0xFF56;
-            gCurrentPinballGame->pokeball->velocity.y = 220;
-            gCurrentPinballGame->pokeball->logicPosition.x = 190;
-            gCurrentPinballGame->pokeball->logicPosition.y = 232;
+            gCurrentPinballGame->ball->unk6 = 0;
+            gCurrentPinballGame->ball->velocity.x = 0xFF56;
+            gCurrentPinballGame->ball->velocity.y = 220;
+            gCurrentPinballGame->ball->positionQ0.x = 190;
+            gCurrentPinballGame->ball->positionQ0.y = 232;
             gCurrentPinballGame->unk2F4 = 18;
             if (gCurrentPinballGame->unk28 == 18)
             {
@@ -202,36 +202,36 @@ void sub_1AAA0(void)
         }
         else if (gCurrentPinballGame->unk28 > 12) 
         {
-            gCurrentPinballGame->pokeball->unk6 = 0;
+            gCurrentPinballGame->ball->unk6 = 0;
             gCurrentPinballGame->unk2F4 = 19;
         }
         else if (gCurrentPinballGame->unk28 > 8) 
         {
-            gCurrentPinballGame->pokeball->unk6 = 0;
+            gCurrentPinballGame->ball->unk6 = 0;
             gCurrentPinballGame->unk2F4 = 20;
         }
         else if (gCurrentPinballGame->unk28 > 4) 
         {
-            gCurrentPinballGame->pokeball->unk6 = 0;
+            gCurrentPinballGame->ball->unk6 = 0;
             gCurrentPinballGame->unk2F4 = 21;
         }
         else
         {
             gCurrentPinballGame->unk2F4 = 22;
         }
-        gCurrentPinballGame->pokeball->halfPxPosition.x = gCurrentPinballGame->pokeball->logicPosition.x * 2;
-        gCurrentPinballGame->pokeball->halfPxPosition.y = gCurrentPinballGame->pokeball->logicPosition.y * 2;
+        gCurrentPinballGame->ball->positionQ1.x = gCurrentPinballGame->ball->positionQ0.x * 2;
+        gCurrentPinballGame->ball->positionQ1.y = gCurrentPinballGame->ball->positionQ0.y * 2;
 
-        gCurrentPinballGame->pokeball->prevHalfPxPosition = gCurrentPinballGame->pokeball->halfPxPosition;
-        gCurrentPinballGame->pokeball->physicsPosition.x= gCurrentPinballGame->pokeball->logicPosition.x << 8;
-        gCurrentPinballGame->pokeball->physicsPosition.y = gCurrentPinballGame->pokeball->logicPosition.y << 8;
+        gCurrentPinballGame->ball->prevPositionQ1 = gCurrentPinballGame->ball->positionQ1;
+        gCurrentPinballGame->ball->positionQ8.x= gCurrentPinballGame->ball->positionQ0.x << 8;
+        gCurrentPinballGame->ball->positionQ8.y = gCurrentPinballGame->ball->positionQ0.y << 8;
         
     }
     else
     {
         gCurrentPinballGame->unk26 = 30;
-        gCurrentPinballGame->pokeball->halfPxPosition.x = gCurrentPinballGame->pokeball->logicPosition.x * 2;
-        gCurrentPinballGame->pokeball->halfPxPosition.y = gCurrentPinballGame->pokeball->logicPosition.y * 2;
+        gCurrentPinballGame->ball->positionQ1.x = gCurrentPinballGame->ball->positionQ0.x * 2;
+        gCurrentPinballGame->ball->positionQ1.y = gCurrentPinballGame->ball->positionQ0.y * 2;
         gCurrentPinballGame->unk25 = 0;
         gCurrentPinballGame->unk5F7 = 0;
         gCurrentPinballGame->unk2F4 = 0;

--- a/src/rom_31F6C.c
+++ b/src/rom_31F6C.c
@@ -516,17 +516,17 @@ void sub_329F4(void)
 
     if (gCurrentPinballGame->unk28 > 0x18)
     {
-        gCurrentPinballGame->unk132c->unk0 = 1;
+        gCurrentPinballGame->pokeball->unk0 = 1;
         gCurrentPinballGame->unk1F = 1;
         gCurrentPinballGame->unk28--;
-        gCurrentPinballGame->unk132c->velocity.x = 0;
-        gCurrentPinballGame->unk132c->velocity.y = 0;
-        gCurrentPinballGame->unk132c->unk10.x = 58;
-        gCurrentPinballGame->unk132c->unk10.y = 178;
-        gCurrentPinballGame->unk132c->unk28.x = gCurrentPinballGame->unk132c->unk10.x * 2;
-        gCurrentPinballGame->unk132c->unk28.y = gCurrentPinballGame->unk132c->unk10.y * 2;
-        gCurrentPinballGame->unk132c->position.x = gCurrentPinballGame->unk132c->unk10.x << 8;
-        gCurrentPinballGame->unk132c->position.y = gCurrentPinballGame->unk132c->unk10.y << 8;
+        gCurrentPinballGame->pokeball->velocity.x = 0;
+        gCurrentPinballGame->pokeball->velocity.y = 0;
+        gCurrentPinballGame->pokeball->logicPosition.x = 58;
+        gCurrentPinballGame->pokeball->logicPosition.y = 178;
+        gCurrentPinballGame->pokeball->halfPxPosition.x = gCurrentPinballGame->pokeball->logicPosition.x * 2;
+        gCurrentPinballGame->pokeball->halfPxPosition.y = gCurrentPinballGame->pokeball->logicPosition.y * 2;
+        gCurrentPinballGame->pokeball->physicsPosition.x = gCurrentPinballGame->pokeball->logicPosition.x << 8;
+        gCurrentPinballGame->pokeball->physicsPosition.y = gCurrentPinballGame->pokeball->logicPosition.y << 8;
 
         if (gCurrentPinballGame->unk28 <= 0x31)
         {
@@ -551,17 +551,17 @@ void sub_329F4(void)
     }
     else
     {
-        gCurrentPinballGame->unk132c->unk0 = 0;
+        gCurrentPinballGame->pokeball->unk0 = 0;
         gCurrentPinballGame->unk1F = 0;
         gCurrentPinballGame->unk26 = 0x3C;
-        gCurrentPinballGame->unk132c->velocity.x = 0x60;
-        gCurrentPinballGame->unk132c->velocity.y = 0xC0;
-        gCurrentPinballGame->unk132c->unk10.x = 0x3C;
-        gCurrentPinballGame->unk132c->unk10.y = 0xB4;
-        gCurrentPinballGame->unk132c->unk6 = 0;
+        gCurrentPinballGame->pokeball->velocity.x = 0x60;
+        gCurrentPinballGame->pokeball->velocity.y = 0xC0;
+        gCurrentPinballGame->pokeball->logicPosition.x = 0x3C;
+        gCurrentPinballGame->pokeball->logicPosition.y = 0xB4;
+        gCurrentPinballGame->pokeball->unk6 = 0;
         gCurrentPinballGame->unk5F7 = 0;
-        gCurrentPinballGame->unk132c->unk28.x = gCurrentPinballGame->unk132c->unk10.x * 2;
-        gCurrentPinballGame->unk132c->unk28.y = gCurrentPinballGame->unk132c->unk10.y * 2;
+        gCurrentPinballGame->pokeball->halfPxPosition.x = gCurrentPinballGame->pokeball->logicPosition.x * 2;
+        gCurrentPinballGame->pokeball->halfPxPosition.y = gCurrentPinballGame->pokeball->logicPosition.y * 2;
         gCurrentPinballGame->unk25 = 0;
 
         m4aSongNumStart(SE_UNKNOWN_0xC3);
@@ -595,25 +595,25 @@ void sub_32BE4(void)
         gCurrentPinballGame->unk5F7 = 1;
         gCurrentPinballGame->unk1F = 1;
         gCurrentPinballGame->unk28--;
-        gCurrentPinballGame->unk132c->velocity.x = 0;
-        gCurrentPinballGame->unk132c->velocity.y = 0;
-        gCurrentPinballGame->unk132c->unk6 = 0;
+        gCurrentPinballGame->pokeball->velocity.x = 0;
+        gCurrentPinballGame->pokeball->velocity.y = 0;
+        gCurrentPinballGame->pokeball->unk6 = 0;
         if (gCurrentPinballGame->unk28 > 97)
         {
             gCurrentPinballGame->unk5FA = 1;
             gCurrentPinballGame->unk2F4 = 2;
-            gCurrentPinballGame->unk132c->unk10.x = 0xb5;
-            gCurrentPinballGame->unk132c->unk10.y = 0xc3;
+            gCurrentPinballGame->pokeball->logicPosition.x = 0xb5;
+            gCurrentPinballGame->pokeball->logicPosition.y = 0xc3;
         }
         else if (gCurrentPinballGame->unk28 > 94)
         {
             gCurrentPinballGame->unk2F4 = 3;
-            gCurrentPinballGame->unk132c->unk10.x = 0xb8;
-            gCurrentPinballGame->unk132c->unk10.y = 0xbb;
+            gCurrentPinballGame->pokeball->logicPosition.x = 0xb8;
+            gCurrentPinballGame->pokeball->logicPosition.y = 0xbb;
         }
         else if (gCurrentPinballGame->unk28 > 91)
         {
-            gCurrentPinballGame->unk132c->unk0 = 1;
+            gCurrentPinballGame->pokeball->unk0 = 1;
             gCurrentPinballGame->unk2F4 = 4;
         }
         else if (gCurrentPinballGame->unk28 > 83)
@@ -642,38 +642,38 @@ void sub_32BE4(void)
         }
         else if (gCurrentPinballGame->unk28 > 4)
         {
-            gCurrentPinballGame->unk132c->unk0 = 0;
+            gCurrentPinballGame->pokeball->unk0 = 0;
             gCurrentPinballGame->unk2F4 = 10;
-            gCurrentPinballGame->unk132c->unk10.x = 0xb5;
-            gCurrentPinballGame->unk132c->unk10.y = 0xc3;
+            gCurrentPinballGame->pokeball->logicPosition.x = 0xb5;
+            gCurrentPinballGame->pokeball->logicPosition.y = 0xc3;
         }
         else
         {
             gCurrentPinballGame->unk2F4 = 11;
-            gCurrentPinballGame->unk132c->unk10.x = 0xb0;
-            gCurrentPinballGame->unk132c->unk10.y = 0xca;
+            gCurrentPinballGame->pokeball->logicPosition.x = 0xb0;
+            gCurrentPinballGame->pokeball->logicPosition.y = 0xca;
         }
 
-        gCurrentPinballGame->unk132c->unk28.x = gCurrentPinballGame->unk132c->unk10.x * 2;
-        gCurrentPinballGame->unk132c->unk28.y = gCurrentPinballGame->unk132c->unk10.y * 2;
-        gCurrentPinballGame->unk132c->position.x = gCurrentPinballGame->unk132c->unk10.x << 8;
-        gCurrentPinballGame->unk132c->position.y = gCurrentPinballGame->unk132c->unk10.y << 8;
+        gCurrentPinballGame->pokeball->halfPxPosition.x = gCurrentPinballGame->pokeball->logicPosition.x * 2;
+        gCurrentPinballGame->pokeball->halfPxPosition.y = gCurrentPinballGame->pokeball->logicPosition.y * 2;
+        gCurrentPinballGame->pokeball->physicsPosition.x = gCurrentPinballGame->pokeball->logicPosition.x << 8;
+        gCurrentPinballGame->pokeball->physicsPosition.y = gCurrentPinballGame->pokeball->logicPosition.y << 8;
     }
     else
     {
         gCurrentPinballGame->unk2F4 = 0;
         gCurrentPinballGame->unk1F = 0;
         gCurrentPinballGame->unk26 = 60;
-        gCurrentPinballGame->unk132c->unk6 = 0;
-        gCurrentPinballGame->unk132c->velocity.x = -0x66;
-        gCurrentPinballGame->unk132c->velocity.y = 0xC8;
+        gCurrentPinballGame->pokeball->unk6 = 0;
+        gCurrentPinballGame->pokeball->velocity.x = -0x66;
+        gCurrentPinballGame->pokeball->velocity.y = 0xC8;
         sub_11B0(7);
-        gCurrentPinballGame->unk132c->unk6 = 0;
-        gCurrentPinballGame->unk132c->unk10.x = 0xAB;
-        gCurrentPinballGame->unk132c->unk10.y = 0xD4;
-        gCurrentPinballGame->unk132c->unk28.x = gCurrentPinballGame->unk132c->unk10.x * 2;
-        gCurrentPinballGame->unk132c->unk28.y = gCurrentPinballGame->unk132c->unk10.y * 2;
-        gCurrentPinballGame->unk132c->unk2C = gCurrentPinballGame->unk132c->unk28;
+        gCurrentPinballGame->pokeball->unk6 = 0;
+        gCurrentPinballGame->pokeball->logicPosition.x = 0xAB;
+        gCurrentPinballGame->pokeball->logicPosition.y = 0xD4;
+        gCurrentPinballGame->pokeball->halfPxPosition.x = gCurrentPinballGame->pokeball->logicPosition.x * 2;
+        gCurrentPinballGame->pokeball->halfPxPosition.y = gCurrentPinballGame->pokeball->logicPosition.y * 2;
+        gCurrentPinballGame->pokeball->prevHalfPxPosition = gCurrentPinballGame->pokeball->halfPxPosition;
         gCurrentPinballGame->unk25 = 0;
         gCurrentPinballGame->unk5F7 = 0;
         m4aSongNumStart(SE_UNKNOWN_0xD6);
@@ -739,7 +739,7 @@ void sub_32F3C(void)
     gCurrentPinballGame->timerBonus = 0;
     gCurrentPinballGame->unk383 = 0;
     gCurrentPinballGame->unk388 = 3;
-    gCurrentPinballGame->unk132c->unk0 = 1;
+    gCurrentPinballGame->pokeball->unk0 = 1;
     gCurrentPinballGame->unk385 = 0;
     gCurrentPinballGame->unk386 = 0;
     gCurrentPinballGame->unk387 = 0;

--- a/src/rom_31F6C.c
+++ b/src/rom_31F6C.c
@@ -516,17 +516,17 @@ void sub_329F4(void)
 
     if (gCurrentPinballGame->unk28 > 0x18)
     {
-        gCurrentPinballGame->pokeball->unk0 = 1;
+        gCurrentPinballGame->ball->unk0 = 1;
         gCurrentPinballGame->unk1F = 1;
         gCurrentPinballGame->unk28--;
-        gCurrentPinballGame->pokeball->velocity.x = 0;
-        gCurrentPinballGame->pokeball->velocity.y = 0;
-        gCurrentPinballGame->pokeball->logicPosition.x = 58;
-        gCurrentPinballGame->pokeball->logicPosition.y = 178;
-        gCurrentPinballGame->pokeball->halfPxPosition.x = gCurrentPinballGame->pokeball->logicPosition.x * 2;
-        gCurrentPinballGame->pokeball->halfPxPosition.y = gCurrentPinballGame->pokeball->logicPosition.y * 2;
-        gCurrentPinballGame->pokeball->physicsPosition.x = gCurrentPinballGame->pokeball->logicPosition.x << 8;
-        gCurrentPinballGame->pokeball->physicsPosition.y = gCurrentPinballGame->pokeball->logicPosition.y << 8;
+        gCurrentPinballGame->ball->velocity.x = 0;
+        gCurrentPinballGame->ball->velocity.y = 0;
+        gCurrentPinballGame->ball->positionQ0.x = 58;
+        gCurrentPinballGame->ball->positionQ0.y = 178;
+        gCurrentPinballGame->ball->positionQ1.x = gCurrentPinballGame->ball->positionQ0.x * 2;
+        gCurrentPinballGame->ball->positionQ1.y = gCurrentPinballGame->ball->positionQ0.y * 2;
+        gCurrentPinballGame->ball->positionQ8.x = gCurrentPinballGame->ball->positionQ0.x << 8;
+        gCurrentPinballGame->ball->positionQ8.y = gCurrentPinballGame->ball->positionQ0.y << 8;
 
         if (gCurrentPinballGame->unk28 <= 0x31)
         {
@@ -551,17 +551,17 @@ void sub_329F4(void)
     }
     else
     {
-        gCurrentPinballGame->pokeball->unk0 = 0;
+        gCurrentPinballGame->ball->unk0 = 0;
         gCurrentPinballGame->unk1F = 0;
         gCurrentPinballGame->unk26 = 0x3C;
-        gCurrentPinballGame->pokeball->velocity.x = 0x60;
-        gCurrentPinballGame->pokeball->velocity.y = 0xC0;
-        gCurrentPinballGame->pokeball->logicPosition.x = 0x3C;
-        gCurrentPinballGame->pokeball->logicPosition.y = 0xB4;
-        gCurrentPinballGame->pokeball->unk6 = 0;
+        gCurrentPinballGame->ball->velocity.x = 0x60;
+        gCurrentPinballGame->ball->velocity.y = 0xC0;
+        gCurrentPinballGame->ball->positionQ0.x = 0x3C;
+        gCurrentPinballGame->ball->positionQ0.y = 0xB4;
+        gCurrentPinballGame->ball->unk6 = 0;
         gCurrentPinballGame->unk5F7 = 0;
-        gCurrentPinballGame->pokeball->halfPxPosition.x = gCurrentPinballGame->pokeball->logicPosition.x * 2;
-        gCurrentPinballGame->pokeball->halfPxPosition.y = gCurrentPinballGame->pokeball->logicPosition.y * 2;
+        gCurrentPinballGame->ball->positionQ1.x = gCurrentPinballGame->ball->positionQ0.x * 2;
+        gCurrentPinballGame->ball->positionQ1.y = gCurrentPinballGame->ball->positionQ0.y * 2;
         gCurrentPinballGame->unk25 = 0;
 
         m4aSongNumStart(SE_UNKNOWN_0xC3);
@@ -595,25 +595,25 @@ void sub_32BE4(void)
         gCurrentPinballGame->unk5F7 = 1;
         gCurrentPinballGame->unk1F = 1;
         gCurrentPinballGame->unk28--;
-        gCurrentPinballGame->pokeball->velocity.x = 0;
-        gCurrentPinballGame->pokeball->velocity.y = 0;
-        gCurrentPinballGame->pokeball->unk6 = 0;
+        gCurrentPinballGame->ball->velocity.x = 0;
+        gCurrentPinballGame->ball->velocity.y = 0;
+        gCurrentPinballGame->ball->unk6 = 0;
         if (gCurrentPinballGame->unk28 > 97)
         {
             gCurrentPinballGame->unk5FA = 1;
             gCurrentPinballGame->unk2F4 = 2;
-            gCurrentPinballGame->pokeball->logicPosition.x = 0xb5;
-            gCurrentPinballGame->pokeball->logicPosition.y = 0xc3;
+            gCurrentPinballGame->ball->positionQ0.x = 0xb5;
+            gCurrentPinballGame->ball->positionQ0.y = 0xc3;
         }
         else if (gCurrentPinballGame->unk28 > 94)
         {
             gCurrentPinballGame->unk2F4 = 3;
-            gCurrentPinballGame->pokeball->logicPosition.x = 0xb8;
-            gCurrentPinballGame->pokeball->logicPosition.y = 0xbb;
+            gCurrentPinballGame->ball->positionQ0.x = 0xb8;
+            gCurrentPinballGame->ball->positionQ0.y = 0xbb;
         }
         else if (gCurrentPinballGame->unk28 > 91)
         {
-            gCurrentPinballGame->pokeball->unk0 = 1;
+            gCurrentPinballGame->ball->unk0 = 1;
             gCurrentPinballGame->unk2F4 = 4;
         }
         else if (gCurrentPinballGame->unk28 > 83)
@@ -642,38 +642,38 @@ void sub_32BE4(void)
         }
         else if (gCurrentPinballGame->unk28 > 4)
         {
-            gCurrentPinballGame->pokeball->unk0 = 0;
+            gCurrentPinballGame->ball->unk0 = 0;
             gCurrentPinballGame->unk2F4 = 10;
-            gCurrentPinballGame->pokeball->logicPosition.x = 0xb5;
-            gCurrentPinballGame->pokeball->logicPosition.y = 0xc3;
+            gCurrentPinballGame->ball->positionQ0.x = 0xb5;
+            gCurrentPinballGame->ball->positionQ0.y = 0xc3;
         }
         else
         {
             gCurrentPinballGame->unk2F4 = 11;
-            gCurrentPinballGame->pokeball->logicPosition.x = 0xb0;
-            gCurrentPinballGame->pokeball->logicPosition.y = 0xca;
+            gCurrentPinballGame->ball->positionQ0.x = 0xb0;
+            gCurrentPinballGame->ball->positionQ0.y = 0xca;
         }
 
-        gCurrentPinballGame->pokeball->halfPxPosition.x = gCurrentPinballGame->pokeball->logicPosition.x * 2;
-        gCurrentPinballGame->pokeball->halfPxPosition.y = gCurrentPinballGame->pokeball->logicPosition.y * 2;
-        gCurrentPinballGame->pokeball->physicsPosition.x = gCurrentPinballGame->pokeball->logicPosition.x << 8;
-        gCurrentPinballGame->pokeball->physicsPosition.y = gCurrentPinballGame->pokeball->logicPosition.y << 8;
+        gCurrentPinballGame->ball->positionQ1.x = gCurrentPinballGame->ball->positionQ0.x * 2;
+        gCurrentPinballGame->ball->positionQ1.y = gCurrentPinballGame->ball->positionQ0.y * 2;
+        gCurrentPinballGame->ball->positionQ8.x = gCurrentPinballGame->ball->positionQ0.x << 8;
+        gCurrentPinballGame->ball->positionQ8.y = gCurrentPinballGame->ball->positionQ0.y << 8;
     }
     else
     {
         gCurrentPinballGame->unk2F4 = 0;
         gCurrentPinballGame->unk1F = 0;
         gCurrentPinballGame->unk26 = 60;
-        gCurrentPinballGame->pokeball->unk6 = 0;
-        gCurrentPinballGame->pokeball->velocity.x = -0x66;
-        gCurrentPinballGame->pokeball->velocity.y = 0xC8;
+        gCurrentPinballGame->ball->unk6 = 0;
+        gCurrentPinballGame->ball->velocity.x = -0x66;
+        gCurrentPinballGame->ball->velocity.y = 0xC8;
         sub_11B0(7);
-        gCurrentPinballGame->pokeball->unk6 = 0;
-        gCurrentPinballGame->pokeball->logicPosition.x = 0xAB;
-        gCurrentPinballGame->pokeball->logicPosition.y = 0xD4;
-        gCurrentPinballGame->pokeball->halfPxPosition.x = gCurrentPinballGame->pokeball->logicPosition.x * 2;
-        gCurrentPinballGame->pokeball->halfPxPosition.y = gCurrentPinballGame->pokeball->logicPosition.y * 2;
-        gCurrentPinballGame->pokeball->prevHalfPxPosition = gCurrentPinballGame->pokeball->halfPxPosition;
+        gCurrentPinballGame->ball->unk6 = 0;
+        gCurrentPinballGame->ball->positionQ0.x = 0xAB;
+        gCurrentPinballGame->ball->positionQ0.y = 0xD4;
+        gCurrentPinballGame->ball->positionQ1.x = gCurrentPinballGame->ball->positionQ0.x * 2;
+        gCurrentPinballGame->ball->positionQ1.y = gCurrentPinballGame->ball->positionQ0.y * 2;
+        gCurrentPinballGame->ball->prevPositionQ1 = gCurrentPinballGame->ball->positionQ1;
         gCurrentPinballGame->unk25 = 0;
         gCurrentPinballGame->unk5F7 = 0;
         m4aSongNumStart(SE_UNKNOWN_0xD6);
@@ -739,7 +739,7 @@ void sub_32F3C(void)
     gCurrentPinballGame->timerBonus = 0;
     gCurrentPinballGame->unk383 = 0;
     gCurrentPinballGame->unk388 = 3;
-    gCurrentPinballGame->pokeball->unk0 = 1;
+    gCurrentPinballGame->ball->unk0 = 1;
     gCurrentPinballGame->unk385 = 0;
     gCurrentPinballGame->unk386 = 0;
     gCurrentPinballGame->unk387 = 0;


### PR DESCRIPTION
## Description
Applies names for ballstate > unk10, unk28, unk2C
Renames ballstate > 'position' and 'prevPosition' to reflect that those are only used in the physics calculations, rather than the board logic

Names Pinball game -> unk132c as pokeball.

## **Discord username**
retnuhytnuob