### PR TITLE
Update assembly to use the hex, rather than music name

### DIFF
--- a/asm/rom_14740.s
+++ b/asm/rom_14740.s
@@ -239,7 +239,7 @@ _08014908:
 	strh r1, [r0]
 _08014916:
 	movs r6, #1
-	movs r0, SE_UNKNOWN_0x74
+	movs r0, 0x74 @=SE_UNKNOWN_0x74
 	bl m4aSongNumStart
 	movs r0, #7
 	bl sub_11B0
@@ -1862,7 +1862,7 @@ _08015604:
 	adds r0, r0, r1
 	movs r1, #0x2d
 	strh r1, [r0]
-	movs r0, SE_UNKNOWN_0x76
+	movs r0, 0x76 @=SE_UNKNOWN_0x76
 	bl m4aSongNumStart
 	bl _08016082
 	.align 2, 0
@@ -2071,7 +2071,7 @@ _080157C6:
 	ldrb r0, [r1]
 	adds r0, #1
 	strb r0, [r1]
-	movs r0, SE_UNKNOWN_0x99
+	movs r0, 0x99 @=SE_UNKNOWN_0x99
 	bl m4aSongNumStart
 _080157DC:
 	ldr r0, _080157FC @ =gCurrentPinballGame
@@ -2808,7 +2808,7 @@ _08015D94:
 	adds r0, r0, r3
 	movs r1, #0x3c
 	strb r1, [r0]
-	movs r0, SE_UNKNOWN_0xD8
+	movs r0, 0xD8 @=SE_UNKNOWN_0xD8
 	bl m4aSongNumStart
 _08015DB6:
 	ldr r2, _08015DD8 @ =gCurrentPinballGame
@@ -2990,7 +2990,7 @@ _08015EE2:
 	ldr r1, [r3]
 	ldr r0, _08015F1C @ =0x00001388
 	str r0, [r1, #0x3c]
-	movs r0, SE_UNKNOWN_0xB7
+	movs r0, 0xB7 @=SE_UNKNOWN_0xB7
 	bl m4aSongNumStart
 	b _08016020
 	.align 2, 0
@@ -3041,7 +3041,7 @@ _08015F4E:
 	adds r0, r1, #0
 	strh r0, [r6]
 	strh r3, [r7]
-	movs r0, SE_UNKNOWN_0xB7
+	movs r0, 0xB7 @=SE_UNKNOWN_0xB7
 	bl m4aSongNumStart
 	ldr r1, [r4]
 	ldr r0, _08015F88 @ =0x00001388
@@ -3090,7 +3090,7 @@ _08015F8C:
 	ldrb r0, [r1]
 	adds r0, #1
 	strb r0, [r1]
-	movs r0, SE_UNKNOWN_0xB7
+	movs r0, 0xB7 @=SE_UNKNOWN_0xB7
 	bl m4aSongNumStart
 	ldr r1, [r5]
 	ldr r0, _08015FF0 @ =0x00001388
@@ -3116,7 +3116,7 @@ _08015FF4:
 	strh r0, [r6]
 	movs r4, #1
 	strh r4, [r7]
-	movs r0, SE_UNKNOWN_0xB7
+	movs r0, 0xB7 @=SE_UNKNOWN_0xB7
 	bl m4aSongNumStart
 	ldr r0, [r5]
 	ldr r3, _08016028 @ =0x000002D9
@@ -3163,7 +3163,7 @@ _0801602C:
 	strh r0, [r6]
 	movs r0, #1
 	strh r0, [r7]
-	movs r0, SE_UNKNOWN_0xB7
+	movs r0, 0xB7 @=SE_UNKNOWN_0xB7
 	bl m4aSongNumStart
 	ldr r1, [r5]
 	ldr r0, _0801608C @ =0x00001388
@@ -4059,7 +4059,7 @@ _0801676E:
 	adds r0, r0, r5
 	movs r1, #0x2d
 	strh r1, [r0]
-	movs r0, SE_UNKNOWN_0x76
+	movs r0, 0x76 @=SE_UNKNOWN_0x76
 	bl m4aSongNumStart
 	bl _080171B8
 	.align 2, 0
@@ -4346,7 +4346,7 @@ _080169CA:
 	ldrb r0, [r1]
 	adds r0, #1
 	strb r0, [r1]
-	movs r0, SE_UNKNOWN_0x99
+	movs r0, 0x99 @=SE_UNKNOWN_0x99
 	bl m4aSongNumStart
 _080169E0:
 	ldr r0, _08016A04 @ =gCurrentPinballGame
@@ -4600,7 +4600,7 @@ _08016BB6:
 	ldrsh r0, [r0, r3]
 	cmp r0, #0xd
 	bne _08016BDC
-	movs r0, SE_UNKNOWN_0x99
+	movs r0, 0x99 @=SE_UNKNOWN_0x99
 	bl m4aSongNumStart
 _08016BDC:
 	ldr r1, [r4]

--- a/asm/rom_1AD84.s
+++ b/asm/rom_1AD84.s
@@ -254,7 +254,7 @@ _0801B332:
 	beq _0801B344
 	b _0801B44A
 _0801B344:
-	movs r0, MUS_SHOP
+	movs r0, 0x0B @ =MUS_SHOP
 	bl m4aSongNumStart
 	ldr r0, [r5]
 	movs r1, #0xd3
@@ -325,7 +325,7 @@ _0801B344:
 	movs r1, #0xf
 	strh r1, [r0]
 	strh r3, [r2, #0x28]
-	movs r0, SE_UNKNOWN_0x8F
+	movs r0, 0x8F @=SE_UNKNOWN_0x8F
 	bl m4aSongNumStart
 	mov r5, r8
 	ldr r1, [r5]
@@ -518,7 +518,7 @@ _0801B552:
 	asrs r0, r0, #0x18
 	cmp r0, #0
 	bne _0801B5B2
-	movs r0, SE_UNKNOWN_0x82
+	movs r0, 0x82 @=SE_UNKNOWN_0x82
 	bl m4aSongNumStart
 	mov r1, r8
 	ldr r0, [r1]
@@ -567,7 +567,7 @@ _0801B5B2:
 	ldrsb r4, [r0, r4]
 	cmp r4, #0
 	bne _0801B614
-	movs r0, SE_UNKNOWN_0x82
+	movs r0, 0x82 @=SE_UNKNOWN_0x82
 	bl m4aSongNumStart
 	ldr r0, [r5]
 	movs r2, #0xd3
@@ -831,7 +831,7 @@ _0801B7AC:
 	subs r0, r0, r3
 	strb r0, [r1]
 	bl m4aMPlayAllStop
-	movs r0, SE_UNKNOWN_0x83
+	movs r0, 0x83 @=SE_UNKNOWN_0x83
 	bl m4aSongNumStart
 	ldr r0, [r4]
 	ldr r2, _0801B81C @ =0x000001AB
@@ -854,7 +854,7 @@ _0801B818: .4byte 0x000006DC
 _0801B81C: .4byte 0x000001AB
 _0801B820: .4byte 0x00000376
 _0801B824:
-	movs r0, SE_FAILURE
+	movs r0, 0x8A @ SE_FAILURE
 	bl m4aSongNumStart
 	b _0801B85E
 _0801B82C:
@@ -880,7 +880,7 @@ _0801B82C:
 	lsls r6, r6, #1
 	adds r0, r2, r6
 	strh r1, [r0]
-	movs r0, SE_UNKNOWN_0x66
+	movs r0, 0x66 @=SE_UNKNOWN_0x66
 	bl m4aSongNumStart
 _0801B85E:
 	ldr r0, _0801B928 @ =gCurrentPinballGame
@@ -1130,7 +1130,7 @@ _0801BA4A:
 	ands r0, r1
 	cmp r0, #0
 	bne _0801BA94
-	movs r0, MUS_FIELD_RUBY
+	movs r0, 0x1C @ =MUS_FIELD_RUBY
 	bl m4aSongNumStart
 	b _0801BAC6
 	.align 2, 0
@@ -1143,7 +1143,7 @@ _0801BA88: .4byte 0x00000252
 _0801BA8C: .4byte gMain
 _0801BA90: .4byte 0x00000283
 _0801BA94:
-	movs r0, MUS_FIELD_RUBY2
+	movs r0, 0x5B @ =MUS_FIELD_RUBY2
 	bl m4aSongNumStart
 	b _0801BAC6
 _0801BA9C:
@@ -1158,13 +1158,13 @@ _0801BA9C:
 	ands r0, r1
 	cmp r0, #0
 	bne _0801BAC0
-	movs r0, MUS_FIELD_SAPPHIRE
+	movs r0, 0x20 @ =MUS_FIELD_SAPPHIRE
 	bl m4aSongNumStart
 	b _0801BAC6
 	.align 2, 0
 _0801BABC: .4byte 0x00000283
 _0801BAC0:
-	movs r0, MUS_FIELD_SAPPHIRE2
+	movs r0, 0x5C @ =MUS_FIELD_SAPPHIRE2
 	bl m4aSongNumStart
 _0801BAC6:
 	ldr r0, _0801BAE4 @ =gCurrentPinballGame
@@ -1454,7 +1454,7 @@ _0801BCF8:
 	ldrb r0, [r0, #4]
 	cmp r0, #0
 	bne _0801BD50
-	movs r0, MUS_EVO_MODE
+	movs r0, 0x1E @ =MUS_EVO_MODE
 	bl m4aSongNumStart
 	b _0801BD56
 	.align 2, 0
@@ -1476,7 +1476,7 @@ _0801BD44: .4byte 0x05000180
 _0801BD48: .4byte 0x0000025D
 _0801BD4C: .4byte gSpeciesInfo
 _0801BD50:
-	movs r0, MUS_EVO_MODE2
+	movs r0, 0x22 @ =MUS_EVO_MODE2
 	bl m4aSongNumStart
 _0801BD56:
 	adds r0, r7, #0
@@ -1630,7 +1630,7 @@ _0801BE84:
 	ands r0, r1
 	cmp r0, #0
 	beq _0801BEEC
-	movs r0, SE_UNKNOWN_0x82
+	movs r0, 0x82 @=SE_UNKNOWN_0x82
 	bl m4aSongNumStart
 	ldr r2, [r4]
 	movs r3, #0xa0
@@ -1681,7 +1681,7 @@ _0801BEEC:
 	ands r0, r1
 	cmp r0, #0
 	beq _0801BFA6
-	movs r0, SE_UNKNOWN_0x82
+	movs r0, 0x82 @=SE_UNKNOWN_0x82
 	bl m4aSongNumStart
 	ldr r0, [r4]
 	movs r1, #0xa0
@@ -1800,7 +1800,7 @@ _0801BFA6:
 	ldrb r5, [r0, #0x15]
 	cmp r5, #0xcc
 	bgt _0801C058
-	movs r0, SE_UNKNOWN_0x82
+	movs r0, 0x82 @=SE_UNKNOWN_0x82
 	bl m4aSongNumStart
 	ldr r1, [r6]
 	ldr r4, _0801C010 @ =0x0000059A
@@ -1837,7 +1837,7 @@ _0801C014:
 	ldrb r5, [r0, #0x15]
 	cmp r5, #0xcc
 	bgt _0801C058
-	movs r0, SE_UNKNOWN_0x82
+	movs r0, 0x82 @=SE_UNKNOWN_0x82
 	bl m4aSongNumStart
 	ldr r1, [r6]
 	ldr r2, _0801C068 @ =0x0000059A
@@ -1891,7 +1891,7 @@ _0801C070:
 	ldrsh r0, [r0, r3]
 	cmp r0, #0xcc
 	bgt _0801C10C
-	movs r0, SE_UNKNOWN_0x82
+	movs r0, 0x82 @=SE_UNKNOWN_0x82
 	bl m4aSongNumStart
 	ldr r1, [r6]
 	ldr r2, _0801C0C0 @ =0x0000059A
@@ -1925,7 +1925,7 @@ _0801C0C4:
 	ldrb r5, [r0, #0x15]
 	cmp r5, #0xcc
 	bgt _0801C10C
-	movs r0, SE_UNKNOWN_0x82
+	movs r0, 0x82 @=SE_UNKNOWN_0x82
 	bl m4aSongNumStart
 	ldr r1, [r6]
 	ldr r4, _0801C14C @ =0x0000059A
@@ -2213,7 +2213,7 @@ _0801C2D8:
 	ldr r0, [r5]
 	adds r0, r0, r4
 	strh r2, [r0]
-	movs r0, SE_UNKNOWN_0x83
+	movs r0, 0x83 @=SE_UNKNOWN_0x83
 	bl m4aSongNumStart
 _0801C31A:
 	ldr r0, _0801C38C @ =gCurrentPinballGame
@@ -2623,7 +2623,7 @@ _0801C644:
 _0801C658:
 	cmp r0, #0x18
 	bne _0801C6B0
-	movs r0, SE_UNKNOWN_0x80
+	movs r0, 0x80 @=SE_UNKNOWN_0x80
 	bl m4aSongNumStart
 	ldr r0, [r5]
 	movs r1, #0xe6

--- a/asm/rom_1D5D8.s
+++ b/asm/rom_1D5D8.s
@@ -92,7 +92,7 @@ _0801D65C:
 	adds r0, r0, r2
 	ldrh r0, [r0]
 	mov r8, r0
-	movs r0, SE_UNKNOWN_0xCF
+	movs r0, 0xCF @=SE_UNKNOWN_0xCF
 	bl m4aSongNumStart
 	movs r0, #7
 	bl sub_11B0
@@ -212,7 +212,7 @@ _0801D760:
 	adds r0, r0, r2
 	ldrh r0, [r0]
 	mov r8, r0
-	movs r0, SE_UNKNOWN_0xCF
+	movs r0, 0xCF @=SE_UNKNOWN_0xCF
 	bl m4aSongNumStart
 	movs r0, #7
 	bl sub_11B0
@@ -273,7 +273,7 @@ _0801D804:
 	adds r1, r1, r5
 	movs r0, #5
 	strb r0, [r1]
-	movs r0, SE_UNKNOWN_0xD1
+	movs r0, 0xD1 @=SE_UNKNOWN_0xD1
 	bl m4aSongNumStart
 _0801D82C:
 	ldr r4, _0801D854 @ =gCurrentPinballGame
@@ -283,7 +283,7 @@ _0801D82C:
 	ldrh r0, [r0]
 	cmp r0, #6
 	bne _0801D840
-	movs r0, SE_UNKNOWN_0xD0
+	movs r0, 0xD0 @=SE_UNKNOWN_0xD0
 	bl m4aSongNumStart
 _0801D840:
 	ldr r2, _0801D85C @ =gUnknown_086AD7C0
@@ -672,7 +672,7 @@ sub_1DAD8: @ 0x0801DAD8
 	ldr r0, [r7]
 	adds r0, #0xfb
 	strb r3, [r0]
-	movs r0, SE_UNKNOWN_0xBD
+	movs r0, 0xBD @=SE_UNKNOWN_0xBD
 	bl m4aSongNumStart
 _0801DB58:
 	ldr r1, [r7]
@@ -1128,7 +1128,7 @@ _0801DEFA:
 	beq _0801DF0C
 	bl _0801E780
 _0801DF0C:
-	movs r0, SE_UNKNOWN_0xD3
+	movs r0, 0xD3 @=SE_UNKNOWN_0xD3
 	bl m4aSongNumStart
 	bl _0801E780
 	.align 2, 0
@@ -1188,7 +1188,7 @@ _0801DF68:
 	ldr r1, [r2]
 	ldr r0, _0801DFBC @ =0x00001388
 	str r0, [r1, #0x3c]
-	movs r0, SE_UNKNOWN_0xD5
+	movs r0, 0xD5 @=SE_UNKNOWN_0xD5
 	bl m4aSongNumStart
 	movs r0, #7
 	bl sub_11B0
@@ -1257,7 +1257,7 @@ _0801E024:
 	asrs r0, r0, #0x18
 	cmp r0, #9
 	bne _0801E038
-	movs r0, SE_UNKNOWN_0xD4
+	movs r0, 0xD4 @=SE_UNKNOWN_0xD4
 	bl m4aSongNumStart
 _0801E038:
 	ldr r5, _0801E0C8 @ =gCurrentPinballGame
@@ -1350,7 +1350,7 @@ _0801E0D0:
 	ldrh r0, [r0]
 	cmp r0, #0x41
 	bne _0801E0F8
-	movs r0, SE_UNKNOWN_0x9F
+	movs r0, 0x9F @=SE_UNKNOWN_0x9F
 	bl m4aSongNumStart
 	ldr r0, _0801E15C @ =gMain
 	ldrh r1, [r0, #0x38]
@@ -1526,7 +1526,7 @@ _0801E24E:
 	asrs r0, r0, #0x18
 	cmp r0, #0xe
 	bne _0801E262
-	movs r0, SE_UNKNOWN_0xD3
+	movs r0, 0xD3 @=SE_UNKNOWN_0xD3
 	bl m4aSongNumStart
 _0801E262:
 	ldr r0, [r4]
@@ -1536,7 +1536,7 @@ _0801E262:
 	asrs r0, r0, #0x18
 	cmp r0, #0x1b
 	bne _0801E276
-	movs r0, SE_UNKNOWN_0xD4
+	movs r0, 0xD4 @=SE_UNKNOWN_0xD4
 	bl m4aSongNumStart
 _0801E276:
 	ldr r0, [r4]
@@ -1546,7 +1546,7 @@ _0801E276:
 	asrs r0, r0, #0x18
 	cmp r0, #0x14
 	bne _0801E2CA
-	movs r0, SE_UNKNOWN_0xD6
+	movs r0, 0xD6 @=SE_UNKNOWN_0xD6
 	bl m4aSongNumStart
 _0801E28A:
 	ldr r1, _0801E2F4 @ =gCurrentPinballGame
@@ -1621,7 +1621,7 @@ _0801E2F8:
 	ldr r1, [r4]
 	movs r0, #0xa
 	str r0, [r1, #0x3c]
-	movs r0, SE_UNKNOWN_0xB6
+	movs r0, 0xB6 @=SE_UNKNOWN_0xB6
 	bl m4aSongNumStart
 	movs r0, #7
 	bl sub_11B0
@@ -1695,7 +1695,7 @@ _0801E3AA:
 	asrs r0, r0, #0x18
 	cmp r0, #0x2a
 	bne _0801E3BE
-	movs r0, SE_UNKNOWN_0xD4
+	movs r0, 0xD4 @=SE_UNKNOWN_0xD4
 	bl m4aSongNumStart
 _0801E3BE:
 	ldr r0, [r4]
@@ -1819,7 +1819,7 @@ _0801E4AA:
 	beq _0801E4BA
 	b _0801E780
 _0801E4BA:
-	movs r0, SE_UNKNOWN_0xD4
+	movs r0, 0xD4 @=SE_UNKNOWN_0xD4
 	bl m4aSongNumStart
 	b _0801E780
 	.align 2, 0
@@ -2095,7 +2095,7 @@ _0801E6C4:
 	lsrs r0, r0, #0x10
 	cmp r0, #0x20
 	bne _0801E6E2
-	movs r0, SE_UNKNOWN_0xC9
+	movs r0, 0xC9 @=SE_UNKNOWN_0xC9
 	bl m4aSongNumStart
 _0801E6E2:
 	ldr r1, [r5]
@@ -2125,7 +2125,7 @@ _0801E714:
 	ldrh r0, [r0]
 	cmp r0, #0x66
 	bne _0801E726
-	movs r0, SE_UNKNOWN_0xC8
+	movs r0, 0xC8 @=SE_UNKNOWN_0xC8
 	bl m4aSongNumStart
 _0801E726:
 	ldr r0, [r5]
@@ -2133,7 +2133,7 @@ _0801E726:
 	ldrh r0, [r0]
 	cmp r0, #0x74
 	bne _0801E736
-	movs r0, SE_UNKNOWN_0xC8
+	movs r0, 0xC8 @=SE_UNKNOWN_0xC8
 	bl m4aSongNumStart
 _0801E736:
 	ldr r0, [r5]
@@ -2147,7 +2147,7 @@ _0801E742:
 	ldrh r0, [r0]
 	cmp r0, #0x66
 	bne _0801E750
-	movs r0, SE_UNKNOWN_0xC8
+	movs r0, 0xC8 @=SE_UNKNOWN_0xC8
 	bl m4aSongNumStart
 _0801E750:
 	ldr r0, [r5]
@@ -2155,7 +2155,7 @@ _0801E750:
 	ldrh r0, [r0]
 	cmp r0, #0x76
 	bne _0801E760
-	movs r0, SE_UNKNOWN_0xC8
+	movs r0, 0xC8 @=SE_UNKNOWN_0xC8
 	bl m4aSongNumStart
 _0801E760:
 	ldr r0, [r5]
@@ -2164,7 +2164,7 @@ _0801E760:
 	cmp r0, #0x86
 	bne _0801E780
 _0801E76A:
-	movs r0, SE_UNKNOWN_0xC8
+	movs r0, 0xC8 @=SE_UNKNOWN_0xC8
 	bl m4aSongNumStart
 	b _0801E780
 _0801E772:
@@ -2172,7 +2172,7 @@ _0801E772:
 	ldrh r0, [r0]
 	cmp r0, #0x68
 	bne _0801E780
-	movs r0, SE_UNKNOWN_0xC8
+	movs r0, 0xC8 @=SE_UNKNOWN_0xC8
 	bl m4aSongNumStart
 _0801E780:
 	ldr r1, _0801E7A4 @ =gCurrentPinballGame
@@ -2773,7 +2773,7 @@ _0801EC6C:
 	movs r0, #0xfa
 	lsls r0, r0, #1
 	str r0, [r3, #0x3c]
-	movs r0, SE_UNKNOWN_0xB6
+	movs r0, 0xB6 @=SE_UNKNOWN_0xB6
 	bl m4aSongNumStart
 	movs r0, #7
 	bl sub_11B0
@@ -4206,7 +4206,7 @@ _0801F7F4:
 	ands r0, r1
 	cmp r0, #0
 	bne _0801F802
-	movs r0, SE_UNKNOWN_0xC6
+	movs r0, 0xC6 @=SE_UNKNOWN_0xC6
 	bl m4aSongNumStart
 _0801F802:
 	mov r1, sb
@@ -4316,7 +4316,7 @@ _0801F8CC:
 	adds r0, r0, r1
 	movs r1, #1
 	strh r1, [r0]
-	movs r0, SE_UNKNOWN_0xC7
+	movs r0, 0xC7 @=SE_UNKNOWN_0xC7
 	bl m4aSongNumStart
 	mov r2, sb
 	ldr r0, [r2]
@@ -4360,7 +4360,7 @@ _0801F934:
 	adds r0, r0, r2
 	movs r1, #1
 	strh r1, [r0]
-	movs r0, SE_UNKNOWN_0xC7
+	movs r0, 0xC7 @=SE_UNKNOWN_0xC7
 	bl m4aSongNumStart
 	mov r3, sb
 	ldr r0, [r3]
@@ -4898,7 +4898,7 @@ _0801FD80:
 	cmp r0, #0x20
 	bne _0801FDFC
 _0801FD8E:
-	movs r0, SE_UNKNOWN_0xD2
+	movs r0, 0xD2 @=SE_UNKNOWN_0xD2
 	bl m4aSongNumStart
 	b _0801FDFC
 _0801FD96:

--- a/asm/rom_1FF0C.s
+++ b/asm/rom_1FF0C.s
@@ -306,7 +306,7 @@ _08020136:
 	strb r4, [r0]
 	movs r0, #7
 	bl sub_11B0
-	movs r0, SE_UNKNOWN_0xB7
+	movs r0, 0xB7 @=SE_UNKNOWN_0xB7
 	bl m4aSongNumStart
 	ldr r0, [r6]
 	ldr r1, _080201A8 @ =0x00000BB8
@@ -1294,7 +1294,7 @@ _08020928:
 	ldr r1, [r2]
 	ldr r0, _08020A48 @ =0x0000FED4
 	strh r0, [r1, #0x32]
-	movs r0, SE_UNKNOWN_0x7C
+	movs r0, 0x7C @=SE_UNKNOWN_0x7C
 	bl m4aSongNumStart
 	mov r7, sl
 	ldr r1, [r7]
@@ -2302,7 +2302,7 @@ _0802114A:
 	lsls r1, r1, #1
 	adds r0, r0, r1
 	strh r4, [r0]
-	movs r0, SE_UNKNOWN_0x75
+	movs r0, 0x75 @=SE_UNKNOWN_0x75
 	bl m4aSongNumStart
 	b _08021210
 	.align 2, 0
@@ -3049,11 +3049,11 @@ _080217AC: @ jump table
 	.4byte _080217C8 @ case 3
 	.4byte _080217C8 @ case 4
 _080217C0:
-	movs r0, MUS_BONUS_CHANCE
+	movs r0, 0x0E @ =MUS_BONUS_CHANCE
 	bl m4aSongNumStart
 	b _080217CE
 _080217C8:
-	movs r0, MUS_BONUS_CHANCE_LEGENDARY
+	movs r0, 0x0F @ =MUS_BONUS_CHANCE_LEGENDARY
 	bl m4aSongNumStart
 _080217CE:
 	bl sub_219A8
@@ -3145,7 +3145,7 @@ _0802187C:
 	cmp r0, #0
 	beq _080218B0
 	bl m4aMPlayAllStop
-	movs r0, SE_UNKNOWN_0x66
+	movs r0, 0x66 @=SE_UNKNOWN_0x66
 	bl m4aSongNumStart
 	ldr r1, [r4]
 	movs r0, #0x3c
@@ -3180,7 +3180,7 @@ _080218C4:
 	ldrh r0, [r0, #0x28]
 	cmp r0, #0x82
 	bne _080218E2
-	movs r0, SE_UNKNOWN_0x9F
+	movs r0, 0x9F @=SE_UNKNOWN_0x9F
 	bl m4aSongNumStart
 	ldr r1, [r4]
 	movs r0, #0x41
@@ -3902,7 +3902,7 @@ _08021E90: .4byte 0x80000010
 _08021E94:
 	cmp r4, #0x25
 	bne _08021E9E
-	movs r0, SE_UNKNOWN_0xCA
+	movs r0, 0xCA @=SE_UNKNOWN_0xCA
 	bl m4aSongNumStart
 _08021E9E:
 	ldr r4, _08021F90 @ =gCurrentPinballGame

--- a/asm/rom_225F0.s
+++ b/asm/rom_225F0.s
@@ -172,7 +172,7 @@ _080226F0:
 	adds r1, r2, r5
 	movs r0, #0x8c
 	strh r0, [r1]
-	movs r0, SE_UNKNOWN_0x7E
+	movs r0, 0x7E @=SE_UNKNOWN_0x7E
 	bl m4aSongNumStart
 	mov r6, sl
 	ldr r1, [r6]
@@ -255,7 +255,7 @@ _080227A4:
 	ldrb r0, [r6]
 	adds r0, #1
 	strb r0, [r6]
-	movs r0, SE_UNKNOWN_0x7E
+	movs r0, 0x7E @=SE_UNKNOWN_0x7E
 	bl m4aSongNumStart
 	mov r6, sl
 	ldr r1, [r6]
@@ -947,7 +947,7 @@ _08022D82:
 	lsls r0, r0, #0x10
 	cmp r0, #0
 	bne _08022D96
-	movs r0, SE_UNKNOWN_0xB8
+	movs r0, 0xB8 @=SE_UNKNOWN_0xB8
 	bl m4aSongNumStart
 _08022D96:
 	mov r2, sl
@@ -2718,7 +2718,7 @@ _08023B9E:
 	ldrh r0, [r0]
 	cmp r0, #0
 	bne _08023BC2
-	movs r0, MUS_EGG_MODE_START
+	movs r0, 0x16 @ =MUS_EGG_MODE_START
 	bl m4aSongNumStart
 _08023BC2:
 	ldr r5, _08023C94 @ =gCurrentPinballGame
@@ -2740,7 +2740,7 @@ _08023BDA:
 	asrs r0, r0, #0x18
 	cmp r0, #0x1c
 	bne _08023BEE
-	movs r0, SE_UNKNOWN_0x92
+	movs r0, 0x92 @=SE_UNKNOWN_0x92
 	bl m4aSongNumStart
 _08023BEE:
 	ldr r2, _08023CA0 @ =gUnknown_086AD2EE
@@ -3296,7 +3296,7 @@ _08024004:
 	ldrsh r0, [r1, r2]
 	lsls r0, r0, #1
 	strh r0, [r1, #0x2a]
-	movs r0, SE_UNKNOWN_0xB9
+	movs r0, 0xB9 @=SE_UNKNOWN_0xB9
 	bl m4aSongNumStart
 	ldr r0, [r7]
 	ldr r3, _08024084 @ =0x000005FA
@@ -3900,7 +3900,7 @@ _08024520:
 	ldrh r0, [r0]
 	cmp r0, #0
 	bne _0802453E
-	movs r0, MUS_EGG_MODE
+	movs r0, 0x15 @ =MUS_EGG_MODE
 	bl m4aSongNumStart
 _0802453E:
 	ldr r4, _0802459C @ =gCurrentPinballGame
@@ -4194,7 +4194,7 @@ _08024784:
 	adds r1, r4, r3
 	movs r0, #3
 	strb r0, [r1]
-	movs r0, SE_UNKNOWN_0xDD
+	movs r0, 0xDD @=SE_UNKNOWN_0xDD
 	bl m4aSongNumStart
 _080247AA:
 	movs r5, #0
@@ -4225,7 +4225,7 @@ _080247BC:
 	movs r0, #2
 	mov sl, r0
 	movs r5, #0
-	movs r0, MUS_EGG_MODE
+	movs r0, 0x15 @ =MUS_EGG_MODE
 	bl m4aSongNumStart
 	b _0802499E
 	.align 2, 0
@@ -4744,7 +4744,7 @@ _08024C24: .4byte gCurrentPinballGame
 _08024C28: .4byte 0x000009C3
 _08024C2C:
 	bl m4aMPlayAllStop
-	movs r0, MUS_END_OF_BALL
+	movs r0, 0x0D @ =MUS_END_OF_BALL
 	bl m4aSongNumStart
 	ldr r0, [r4]
 	movs r1, #0xc8
@@ -4996,7 +4996,7 @@ _08024E0A:
 	movs r0, #4
 	strb r0, [r1, #0x17]
 _08024E38:
-	movs r0, SE_UNKNOWN_0x75
+	movs r0, 0x75 @=SE_UNKNOWN_0x75
 	bl m4aSongNumStart
 	ldr r1, _08024EA8 @ =gCurrentPinballGame
 	ldr r0, [r1]

--- a/asm/rom_2530C.s
+++ b/asm/rom_2530C.s
@@ -429,7 +429,7 @@ _08025650:
 	asrs r0, r0, #0x18
 	cmp r0, #1
 	bne _0802566C
-	movs r0, SE_UNKNOWN_0x8C
+	movs r0, 0x8C @=SE_UNKNOWN_0x8C
 	bl m4aSongNumStart
 	bl sub_29664
 _0802566C:
@@ -732,7 +732,7 @@ _080258A8:
 	movs r4, #0
 	movs r0, #1
 	strh r0, [r1]
-	movs r0, SE_UNKNOWN_0x8D
+	movs r0, 0x8D @=SE_UNKNOWN_0x8D
 	bl m4aSongNumStart
 	ldr r1, [r7]
 	ldr r0, _08025920 @ =0x00000602
@@ -1144,7 +1144,7 @@ _08025C18:
 	adds r0, #1
 	strb r0, [r1]
 	bl sub_29924
-	movs r0, SE_UNKNOWN_0x8E
+	movs r0, 0x8E @=SE_UNKNOWN_0x8E
 	bl m4aSongNumStart
 	b _08025F36
 	.align 2, 0
@@ -2198,7 +2198,7 @@ _08026494:
 	ldr r1, [r0]
 	movs r0, #1
 	strh r0, [r1]
-	movs r0, SE_UNKNOWN_0x93
+	movs r0, 0x93 @=SE_UNKNOWN_0x93
 	bl m4aSongNumStart
 _080264E2:
 	ldr r6, _0802655C @ =gCurrentPinballGame
@@ -2326,7 +2326,7 @@ _080265A8:
 	movs r0, #0
 	movs r1, #1
 	bl sub_1C7F4
-	movs r0, SE_UNKNOWN_0x81
+	movs r0, 0x81 @=SE_UNKNOWN_0x81
 	bl m4aSongNumStart
 	b _0802674E
 	.align 2, 0
@@ -2862,7 +2862,7 @@ sub_26A10: @ 0x08026A10
 	cmp r0, #5
 	bgt _08026A4C
 	bl m4aMPlayAllStop
-	movs r0, MUS_END_OF_BALL2
+	movs r0, 0x13 @ =MUS_END_OF_BALL2
 	bl m4aSongNumStart
 	ldr r0, [r4]
 	movs r1, #0xc8
@@ -2931,7 +2931,7 @@ _08026AC4:
 	ldrh r0, [r0, #0x18]
 	cmp r0, #0x23
 	bne _08026ADC
-	movs r0, MUS_TRAVEL_MODE
+	movs r0, 0x17 @ =MUS_TRAVEL_MODE
 	bl m4aSongNumStart
 _08026ADC:
 	ldr r1, [r4]
@@ -2950,7 +2950,7 @@ _08026ADC:
 	ldrh r0, [r0, #0x18]
 	cmp r0, #0x22
 	bhi _08026B02
-	movs r0, MUS_TRAVEL_MODE
+	movs r0, 0x17 @ =MUS_TRAVEL_MODE
 	bl m4aSongNumStart
 _08026B02:
 	ldr r0, [r4]
@@ -3274,7 +3274,7 @@ _08026D92:
 	cmp r0, #0
 	beq _08026DC6
 	bl m4aMPlayAllStop
-	movs r0, SE_UNKNOWN_0x66
+	movs r0, 0x66 @=SE_UNKNOWN_0x66
 	bl m4aSongNumStart
 	ldr r1, [r4]
 	movs r0, #0x3c
@@ -3656,7 +3656,7 @@ sub_27080: @ 0x08027080
 	cmp r0, #7
 	bgt _080270C0
 	bl m4aMPlayAllStop
-	movs r0, MUS_END_OF_BALL2
+	movs r0, 0x13 @ =MUS_END_OF_BALL2
 	bl m4aSongNumStart
 	ldr r0, [r4]
 	movs r1, #0xc8
@@ -4211,7 +4211,7 @@ _08027520:
 	cmp r1, #0
 	bne _08027534
 	bl sub_2312C
-	movs r0, MUS_SUCCESS2
+	movs r0, 0x12 @ =MUS_SUCCESS2
 	bl m4aSongNumStart
 	b _0802758E
 	.align 2, 0

--- a/asm/rom_27F94.s
+++ b/asm/rom_27F94.s
@@ -29,7 +29,7 @@ sub_27F94: @ 0x08027F94
 	cmp r0, #9
 	bgt _08027FD0
 	bl m4aMPlayAllStop
-	movs r0, MUS_END_OF_BALL2
+	movs r0, 0x13 @ =MUS_END_OF_BALL2
 	bl m4aSongNumStart
 	ldr r0, [r4]
 	movs r1, #0xc8
@@ -177,7 +177,7 @@ _080280F4:
 	beq _08028136
 	cmp r0, #0x49
 	bne _08028118
-	movs r0, MUS_CATCH_EM_MODE
+	movs r0, 0x1D @ =MUS_CATCH_EM_MODE
 	bl m4aSongNumStart
 	b _080281F6
 	.align 2, 0
@@ -275,7 +275,7 @@ _080281D0: .4byte 0x80000010
 _080281D4:
 	cmp r0, #0x2f
 	bne _080281E0
-	movs r0, MUS_CATCH_EM_MODE2
+	movs r0, 0x21 @ =MUS_CATCH_EM_MODE2
 	bl m4aSongNumStart
 	b _080281F6
 _080281E0:
@@ -339,7 +339,7 @@ _08028230:
 	ldr r0, _08028280 @ =0x80000010
 	str r0, [r1, #8]
 	ldr r0, [r1, #8]
-	movs r0, SE_UNKNOWN_0xA7
+	movs r0, 0xA7 @=SE_UNKNOWN_0xA7
 	bl m4aSongNumStart
 	ldr r1, [r5]
 	ldrb r0, [r1, #0x17]
@@ -840,7 +840,7 @@ _08028684:
 	cmp r0, #0x2f
 	bne _08028690
 _08028688:
-	movs r0, MUS_JIRACHI
+	movs r0, 0x2F @ =MUS_JIRACHI
 	bl m4aSongNumStart
 	b _08028AD2
 _08028690:
@@ -1253,7 +1253,7 @@ _080289D6:
 	b _08028AD2
 _080289E0:
 	bl m4aMPlayAllStop
-	movs r0, MUS_END_OF_BALL2
+	movs r0, 0x13 @ =MUS_END_OF_BALL2
 	bl m4aSongNumStart
 	mov r4, r8
 	ldr r1, [r4]
@@ -4425,7 +4425,7 @@ sub_2A354: @ 0x0802A354
 	bhi _0802A3A6
 	cmp r0, #4
 	bne _0802A36E
-	movs r0, MUS_UNKNOWN_0x14
+	movs r0, 0x14 @ =MUS_UNKNOWN_0x14
 	bl m4aSongNumStart
 _0802A36E:
 	ldr r1, [r4]
@@ -4438,7 +4438,7 @@ _0802A36E:
 	ldrh r0, [r0]
 	cmp r0, #0x78
 	bne _0802A388
-	movs r0, SE_UNKNOWN_0xB2
+	movs r0, 0xB2 @=SE_UNKNOWN_0xB2
 	bl m4aSongNumStart
 _0802A388:
 	ldr r0, _0802A3C4 @ =gCurrentPinballGame
@@ -5243,7 +5243,7 @@ _0802AA24:
 	ldrh r0, [r0]
 	cmp r0, #0x46
 	bne _0802AAD2
-	movs r0, SE_UNKNOWN_0x91
+	movs r0, 0x91 @=SE_UNKNOWN_0x91
 	bl m4aSongNumStart
 	ldr r1, [r5]
 	movs r0, #0x64
@@ -5258,7 +5258,7 @@ _0802AA44:
 	ldrh r0, [r0]
 	cmp r0, #0x46
 	bne _0802AAD2
-	movs r0, SE_UNKNOWN_0x91
+	movs r0, 0x91 @=SE_UNKNOWN_0x91
 	bl m4aSongNumStart
 	ldr r1, [r5]
 	movs r0, #0xfa
@@ -5274,7 +5274,7 @@ _0802AA64:
 	ldrh r0, [r0]
 	cmp r0, #0x46
 	bne _0802AAD2
-	movs r0, SE_UNKNOWN_0x91
+	movs r0, 0x91 @=SE_UNKNOWN_0x91
 	bl m4aSongNumStart
 	ldr r1, [r5]
 	movs r0, #0xe1

--- a/asm/rom_2AADC.s
+++ b/asm/rom_2AADC.s
@@ -1179,7 +1179,7 @@ _0802B510:
 	ldrh r0, [r0]
 	cmp r0, #0
 	bne _0802B524
-	movs r0, SE_UNKNOWN_0x9B
+	movs r0, 0x9B @=SE_UNKNOWN_0x9B
 	bl m4aSongNumStart
 _0802B524:
 	ldr r2, _0802B55C @ =0x040000D4
@@ -1625,7 +1625,7 @@ _0802B8AC:
 	beq _0802B8BA
 	bl _0802C4D2
 _0802B8BA:
-	movs r0, SE_UNKNOWN_0x9C
+	movs r0, 0x9C @=SE_UNKNOWN_0x9C
 	bl m4aSongNumStart
 	bl _0802C4D2
 	.align 2, 0
@@ -2126,7 +2126,7 @@ _0802BCA4:
 	ldrsh r0, [r3, r1]
 	cmp r0, #0x31
 	ble _0802BCE8
-	movs r0, SE_UNKNOWN_0x9D
+	movs r0, 0x9D @=SE_UNKNOWN_0x9D
 	bl m4aSongNumStart
 _0802BCE8:
 	ldr r2, _0802BDB4 @ =gCurrentPinballGame
@@ -2139,7 +2139,7 @@ _0802BCE8:
 	rsbs r0, r0, #0
 	cmp r1, r0
 	bgt _0802BD02
-	movs r0, SE_UNKNOWN_0x9D
+	movs r0, 0x9D @=SE_UNKNOWN_0x9D
 	bl m4aSongNumStart
 _0802BD02:
 	ldr r0, _0802BDB4 @ =gCurrentPinballGame
@@ -2260,7 +2260,7 @@ _0802BDC4:
 	ldr r1, [r1, #0x38]
 	cmp r1, r0
 	blt _0802BE78
-	movs r0, SE_UNKNOWN_0x9D
+	movs r0, 0x9D @=SE_UNKNOWN_0x9D
 	bl m4aSongNumStart
 	ldr r4, _0802BE90 @ =gCurrentPinballGame
 	ldr r0, [r4]
@@ -2372,7 +2372,7 @@ _0802BECE:
 _0802BEDC:
 	cmp r4, #0xb8
 	bne _0802BEE6
-	movs r0, SE_UNKNOWN_0x9E
+	movs r0, 0x9E @=SE_UNKNOWN_0x9E
 	bl m4aSongNumStart
 _0802BEE6:
 	ldr r1, [r6]
@@ -2411,7 +2411,7 @@ _0802BF20:
 _0802BF2E:
 	cmp r4, #0xa8
 	bne _0802BF38
-	movs r0, SE_UNKNOWN_0x9E
+	movs r0, 0x9E @=SE_UNKNOWN_0x9E
 	bl m4aSongNumStart
 _0802BF38:
 	ldr r1, [r6]
@@ -2460,7 +2460,7 @@ _0802BF80:
 _0802BF92:
 	cmp r4, #0x74
 	bne _0802BF9C
-	movs r0, SE_UNKNOWN_0x9E
+	movs r0, 0x9E @=SE_UNKNOWN_0x9E
 	bl m4aSongNumStart
 _0802BF9C:
 	ldr r1, [r6]
@@ -2504,7 +2504,7 @@ _0802BFDC:
 _0802BFEA:
 	cmp r4, #0x64
 	bne _0802BFF4
-	movs r0, SE_UNKNOWN_0x9E
+	movs r0, 0x9E @=SE_UNKNOWN_0x9E
 	bl m4aSongNumStart
 _0802BFF4:
 	ldr r1, [r6]
@@ -2547,7 +2547,7 @@ _0802C036:
 	beq _0802C03C
 	b _0802C4D2
 _0802C03C:
-	movs r0, MUS_SUCCESS
+	movs r0, 0x11 @ =MUS_SUCCESS
 	bl m4aSongNumStart
 	bl sub_2312C
 	b _0802C4D2
@@ -3604,7 +3604,7 @@ _0802C852:
 	asrs r0, r0, #0x18
 	cmp r0, #0
 	bgt _0802C8C0
-	movs r0, SE_UNKNOWN_0xC5
+	movs r0, 0xC5 @=SE_UNKNOWN_0xC5
 	bl m4aSongNumStart
 	ldr r1, [r7]
 	ldr r0, _0802C97C @ =0x00002710
@@ -4524,7 +4524,7 @@ _0802CFE8:
 	ldrh r0, [r0]
 	cmp r0, #0
 	bne _0802CFFE
-	movs r0, SE_UNKNOWN_0xCC
+	movs r0, 0xCC @=SE_UNKNOWN_0xCC
 	bl m4aSongNumStart
 _0802CFFE:
 	ldr r1, [r5]
@@ -4949,7 +4949,7 @@ _0802D320:
 	ldr r0, [r1, #8]
 	cmp r5, #0x1e
 	bne _0802D33A
-	movs r0, MUS_EVOLUTION
+	movs r0, 0x1A @ =MUS_EVOLUTION
 	bl m4aSongNumStart
 _0802D33A:
 	ldr r0, _0802D390 @ =gMain
@@ -5195,7 +5195,7 @@ _0802D53E:
 	asrs r0, r1, #0x10
 	cmp r0, #0xa
 	bne _0802D54C
-	movs r0, SE_UNKNOWN_0xB0
+	movs r0, 0xB0 @=SE_UNKNOWN_0xB0
 	bl m4aSongNumStart
 _0802D54C:
 	ldr r1, _0802D5CC @ =gCurrentPinballGame
@@ -6774,7 +6774,7 @@ _0802E180:
 	beq _0802E210
 	b _0802E4E0
 _0802E210:
-	movs r0, SE_UNKNOWN_0x97
+	movs r0, 0x97 @=SE_UNKNOWN_0x97
 	bl m4aSongNumStart
 	b _0802E4E0
 	.align 2, 0
@@ -6973,7 +6973,7 @@ _0802E37A:
 	ldrh r0, [r0]
 	cmp r0, #1
 	bne _0802E3B4
-	movs r0, SE_UNKNOWN_0x98
+	movs r0, 0x98 @=SE_UNKNOWN_0x98
 	bl m4aSongNumStart
 _0802E3B4:
 	cmp r7, #0x10
@@ -7057,7 +7057,7 @@ _0802E45C:
 	movs r7, #0xc
 	cmp r3, #0x18
 	bne _0802E4E0
-	movs r0, MUS_SUCCESS
+	movs r0, 0x11 @ =MUS_SUCCESS
 	bl m4aSongNumStart
 	b _0802E4E0
 _0802E46E:
@@ -7115,7 +7115,7 @@ _0802E496:
 	lsls r0, r0, #0x10
 	cmp r0, #0
 	bne _0802E4E0
-	movs r0, SE_UNKNOWN_0x97
+	movs r0, 0x97 @=SE_UNKNOWN_0x97
 	bl m4aSongNumStart
 _0802E4E0:
 	ldr r0, _0802E504 @ =gMain

--- a/asm/rom_2E6AC.s
+++ b/asm/rom_2E6AC.s
@@ -161,7 +161,7 @@ _0802E7D4:
 	strh r2, [r1, #0x32]
 	ldr r0, [r0]
 	strh r2, [r0, #6]
-	movs r0, SE_UNKNOWN_0xE2
+	movs r0, 0xE2 @=SE_UNKNOWN_0xE2
 	bl m4aSongNumStart
 	movs r0, #7
 	bl sub_11B0
@@ -323,7 +323,7 @@ _0802E948:
 	asrs r0, r0, #0x18
 	cmp r0, #1
 	bne _0802E95C
-	movs r0, SE_UNKNOWN_0xE3
+	movs r0, 0xE3 @=SE_UNKNOWN_0xE3
 	bl m4aSongNumStart
 _0802E95C:
 	ldr r2, _0802E994 @ =gUnknown_086AE3DC
@@ -537,7 +537,7 @@ _0802EB06:
 	beq _0802EB1A
 	b _0802EFFC
 _0802EB1A:
-	movs r0, SE_UNKNOWN_0xE3
+	movs r0, 0xE3 @=SE_UNKNOWN_0xE3
 	bl m4aSongNumStart
 	b _0802EFFC
 	.align 2, 0
@@ -566,7 +566,7 @@ _0802EB2C:
 	ldrh r0, [r0]
 	cmp r0, #0x41
 	bne _0802EB66
-	movs r0, SE_UNKNOWN_0x9F
+	movs r0, 0x9F @=SE_UNKNOWN_0x9F
 	bl m4aSongNumStart
 	ldr r0, _0802EBCC @ =gMain
 	ldrh r1, [r0, #0x38]
@@ -710,7 +710,7 @@ _0802EC40:
 	ldrh r0, [r4]
 	cmp r0, #0
 	bne _0802EC9A
-	movs r0, SE_UNKNOWN_0xE4
+	movs r0, 0xE4 @=SE_UNKNOWN_0xE4
 	bl m4aSongNumStart
 _0802EC9A:
 	ldr r2, [r6]
@@ -762,7 +762,7 @@ _0802ECE0:
 	adds r1, r1, r5
 	ldr r0, _0802EDFC @ =0x0000FC18
 	strh r0, [r1]
-	movs r0, SE_UNKNOWN_0xE3
+	movs r0, 0xE3 @=SE_UNKNOWN_0xE3
 	bl m4aSongNumStart
 	ldr r0, [r6]
 	movs r1, #0xc4
@@ -957,7 +957,7 @@ _0802EE14:
 	ldr r0, [r7]
 	adds r0, #0x24
 	strb r5, [r0]
-	movs r0, SE_UNKNOWN_0xE5
+	movs r0, 0xE5 @=SE_UNKNOWN_0xE5
 	bl m4aSongNumStart
 	movs r0, #7
 	bl sub_11B0
@@ -1594,7 +1594,7 @@ _0802F384:
 	ldr r0, _0802F400 @ =0x80000600
 	str r0, [r1, #8]
 	ldr r0, [r1, #8]
-	movs r0, SE_UNKNOWN_0xEC
+	movs r0, 0xEC @=SE_UNKNOWN_0xEC
 	bl m4aSongNumStart
 	ldr r1, [r5]
 	ldr r0, _0802F404 @ =0x00001388
@@ -2214,7 +2214,7 @@ _0802F8BC:
 	ldrsb r0, [r1, r0]
 	cmp r0, #5
 	bne _0802F8EC
-	movs r0, SE_UNKNOWN_0xE6
+	movs r0, 0xE6 @=SE_UNKNOWN_0xE6
 	bl m4aSongNumStart
 	ldr r1, [r7]
 	movs r0, #0xfa
@@ -2314,7 +2314,7 @@ _0802F980:
 	ldrsb r0, [r1, r0]
 	cmp r0, #8
 	bne _0802F9AC
-	movs r0, SE_UNKNOWN_0xE7
+	movs r0, 0xE7 @=SE_UNKNOWN_0xE7
 	bl m4aSongNumStart
 _0802F9AC:
 	mov r1, r8
@@ -2564,7 +2564,7 @@ _0802FB78:
 	beq _0802FBCE
 	cmp r0, #0x11
 	bne _0802FB9E
-	movs r0, SE_UNKNOWN_0xE8
+	movs r0, 0xE8 @=SE_UNKNOWN_0xE8
 	bl m4aSongNumStart
 	ldr r1, [r4]
 	movs r0, #0xa
@@ -3311,7 +3311,7 @@ _080301A0:
 	movs r0, #0xfa
 	lsls r0, r0, #1
 	str r0, [r3, #0x3c]
-	movs r0, SE_UNKNOWN_0xB6
+	movs r0, 0xB6 @=SE_UNKNOWN_0xB6
 	bl m4aSongNumStart
 	movs r0, #7
 	bl sub_11B0

--- a/asm/rom_304C8.s
+++ b/asm/rom_304C8.s
@@ -251,7 +251,7 @@ _08030696:
 	ldrh r0, [r0]
 	cmp r0, #0
 	bne _080306BA
-	movs r0, MUS_EGG_MODE_START
+	movs r0, 0x16 @ =MUS_EGG_MODE_START
 	bl m4aSongNumStart
 _080306BA:
 	ldr r5, _08030784 @ =gCurrentPinballGame
@@ -273,7 +273,7 @@ _080306D2:
 	asrs r0, r0, #0x18
 	cmp r0, #0x1c
 	bne _080306E6
-	movs r0, SE_UNKNOWN_0x92
+	movs r0, 0x92 @=SE_UNKNOWN_0x92
 	bl m4aSongNumStart
 _080306E6:
 	ldr r2, _0803078C @ =gUnknown_086AD2EE
@@ -768,7 +768,7 @@ _08030AAC:
 	bhi _08030B58
 	cmp r0, #0
 	bne _08030AC6
-	movs r0, SE_UNKNOWN_0xE9
+	movs r0, 0xE9 @=SE_UNKNOWN_0xE9
 	bl m4aSongNumStart
 _08030AC6:
 	mov r1, sb
@@ -778,7 +778,7 @@ _08030AC6:
 	ldrh r0, [r0]
 	cmp r0, #0x1a
 	bne _08030ADA
-	movs r0, SE_UNKNOWN_0xEA
+	movs r0, 0xEA @=SE_UNKNOWN_0xEA
 	bl m4aSongNumStart
 _08030ADA:
 	mov r3, sb
@@ -946,7 +946,7 @@ _08030C10:
 	ands r4, r0
 	cmp r4, #0
 	bne _08030C28
-	movs r0, SE_UNKNOWN_0xEB
+	movs r0, 0xEB @=SE_UNKNOWN_0xEB
 	bl m4aSongNumStart
 _08030C28:
 	mov r0, sb


### PR DESCRIPTION
## Description
M2C and Decomp me can't recognize the music with the name; wants it as the hex number for its initial parsing of the assembly.

This gives those hex values in the assembly, while keeping the SE/MUS name in a comment on the same line, to simplify setting those up for decomp work.

## **Discord username**
retnuhytnuob