### PR TITLE
rgb defines

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -978,7 +978,7 @@ extern struct PinballGame gIdleBoardGameState2;
 extern struct PinballGame gIdleBoardGameState3;
 extern struct PinballGame gIdleBoardGameState1;
 extern s32 gBonusStageObjPal[64];
-extern s32 gDusclopsAnimPalettes[0x3E0];
+extern s32 gDusclopsAnimPalettes[];
 extern u16 gKecleonUprightCollisionMap[0x1600];
 extern u16 gKecleonKnockedDownCollisionMap[0x1600];
 extern u16 gKyogreForm1CollisionMap[];

--- a/include/types.h
+++ b/include/types.h
@@ -83,4 +83,13 @@ struct PokemonSpecies {
     /*0x15*/ u8 evolutionTarget; // Uses the standard index numbers; e.g. Treecko is 0x00 (SPECIES_TREECKO)
 };
 
+
+#define RGB5_GET_R(color) ((color) & 0x1F)
+#define RGB5_GET_G(color) (((color) & 0x3E0) >> 5)
+#define RGB5_GET_B(color) (((color) & 0x7C00) >> 10)
+
+#define RGB5_R(r) ((r))
+#define RGB5_G(g) ((g) << 5)
+#define RGB5_B(b) ((b) << 10)
+
 #endif  // GUARD_TYPES_H

--- a/src/all_board_portrait_display.c
+++ b/src/all_board_portrait_display.c
@@ -143,10 +143,11 @@ void LoadPortraitGraphics(s16 displayMode, s16 picIx)
             DmaCopy16(3, &gPortraitAnim_Pals[index], tempPal, PLTT_SLOT_SIZE);
             for (i = 0; i < 16; i++)
             {
-                rgb[0] = ((tempPal[i] & 0x1F) * 2) / 3;
-                rgb[1] = ((tempPal[i] & 0x3E0) >> 4) / 3;
-                rgb[2] = ((tempPal[i] & 0x7C00) >> 9) / 3;
-                tempPal[i] = rgb[0] | (rgb[1] << 5) | (rgb[2] << 10);
+                rgb[0] = RGB5_GET_R(tempPal[i]) * 2 / 3;
+                rgb[1] = RGB5_GET_G(tempPal[i]) * 2 / 3;
+                rgb[2] = RGB5_GET_B(tempPal[i]) * 2 / 3;
+
+                tempPal[i] = RGB5_R(rgb[0]) | RGB5_G(rgb[1]) | RGB5_B(rgb[2]);
             }
 
             DmaCopy16(3, tempPal, OBJ_PLTT_SLOT(gPortraitPaletteSlots[picIx]), PLTT_SLOT_SIZE);

--- a/src/display.c
+++ b/src/display.c
@@ -134,13 +134,13 @@ void InterpolatePaletteStep(u16 arg0)
 
     while(var0 < var1)
     {
-        r[0] = gPaletteFadeBuffers[0][var0] & 0x1F;
-        g[0] = (gPaletteFadeBuffers[0][var0] & 0x3E0) >> 5;
-        b[0] = (gPaletteFadeBuffers[0][var0] & 0x7C00) >> 10;
+        r[0] = RGB5_GET_R(gPaletteFadeBuffers[0][var0]);
+        g[0] = RGB5_GET_G(gPaletteFadeBuffers[0][var0]);
+        b[0] = RGB5_GET_B(gPaletteFadeBuffers[0][var0]);
 
-        r[1] = gPaletteFadeBuffers[1][var0] & 0x1F;
-        g[1] = (gPaletteFadeBuffers[1][var0] & 0x3E0) >> 5;
-        b[1] = (gPaletteFadeBuffers[1][var0] & 0x7C00) >> 10;
+        r[1] = RGB5_GET_R(gPaletteFadeBuffers[1][var0]);
+        g[1] = RGB5_GET_G(gPaletteFadeBuffers[1][var0]);
+        b[1] = RGB5_GET_B(gPaletteFadeBuffers[1][var0]);
 
         if(b[0] < b[1])
             b[0] += ((b[1] - b[0]) * arg0) >> 5;
@@ -157,7 +157,7 @@ void InterpolatePaletteStep(u16 arg0)
         else
             r[0] -= ((r[0] - r[1]) * arg0) >> 5;
 
-        gPaletteFadeBuffers[2][var0] = (b[0] << 10) | (g[0] << 5) | r[0];
+        gPaletteFadeBuffers[2][var0] = RGB5_B(b[0]) | RGB5_G(g[0]) | RGB5_R(r[0]);
         var0++;
     }
 }
@@ -173,13 +173,13 @@ void DarkenPalette(const Palette * pal, u8 * dest, u16 arg2, u16 arg3)
 
     for(i = 0; i < arg2; i++)
     {
-        r[0] = gPaletteFadeBuffers[0][i] & 0x1F;
-        g[0] = (gPaletteFadeBuffers[0][i] & 0x3E0) >> 5;
-        b[0] = (gPaletteFadeBuffers[0][i] & 0x7C00) >> 10;
+        r[0] = RGB5_GET_R(gPaletteFadeBuffers[0][i]);
+        g[0] = RGB5_GET_G(gPaletteFadeBuffers[0][i]);
+        b[0] = RGB5_GET_B(gPaletteFadeBuffers[0][i]);
 
-        r[1] = gPaletteFadeBuffers[1][i] & 0x1F;
-        g[1] = (gPaletteFadeBuffers[1][i] & 0x3E0) >> 5;
-        b[1] = (gPaletteFadeBuffers[1][i] & 0x7C00) >> 10;
+        r[1] = RGB5_GET_R(gPaletteFadeBuffers[1][i]);
+        g[1] = RGB5_GET_G(gPaletteFadeBuffers[1][i]);
+        b[1] = RGB5_GET_B(gPaletteFadeBuffers[1][i]);
 
         if(b[0] > b[1])
             b[0] -= (b[0] * arg3) >> 5;
@@ -196,7 +196,7 @@ void DarkenPalette(const Palette * pal, u8 * dest, u16 arg2, u16 arg3)
         else
             r[0] = r[1];
 
-        gPaletteFadeBuffers[2][i] = (b[0] << 10) | (g[0] << 5) | r[0];
+        gPaletteFadeBuffers[2][i] = RGB5_B(b[0]) | RGB5_G(g[0]) | RGB5_R(r[0]);
     }
     DmaCopy16(3, gPaletteFadeBuffers[2], dest, arg2);
 }
@@ -212,13 +212,13 @@ void BrightenPalette(const Palette * pal, u8 * dest, u16 arg2, u16 arg3)
 
     for(i = 0; i < arg2; i++)
     {
-        r[0] = gPaletteFadeBuffers[0][i] & 0x1F;
-        g[0] = (gPaletteFadeBuffers[0][i] & 0x3E0) >> 5;
-        b[0] = (gPaletteFadeBuffers[0][i] & 0x7C00) >> 10;
+        r[0] = RGB5_GET_R(gPaletteFadeBuffers[0][i]);
+        g[0] = RGB5_GET_G(gPaletteFadeBuffers[0][i]);
+        b[0] = RGB5_GET_B(gPaletteFadeBuffers[0][i]);
 
-        r[1] = gPaletteFadeBuffers[1][i] & 0x1F;
-        g[1] = (gPaletteFadeBuffers[1][i] & 0x3E0) >> 5;
-        b[1] = (gPaletteFadeBuffers[1][i] & 0x7C00) >> 10;
+        r[1] = RGB5_GET_R(gPaletteFadeBuffers[1][i]);
+        g[1] = RGB5_GET_G(gPaletteFadeBuffers[1][i]);
+        b[1] = RGB5_GET_B(gPaletteFadeBuffers[1][i]);
 
         if(b[0] < b[1])
             b[0] += ((b[1] - b[0]) * arg3) >> 5;
@@ -235,7 +235,7 @@ void BrightenPalette(const Palette * pal, u8 * dest, u16 arg2, u16 arg3)
         else
             r[0] -= ((r[0] - r[1]) * arg3) >> 5;
 
-        gPaletteFadeBuffers[2][i] = (b[0] << 10) | (g[0] << 5) | r[0];
+        gPaletteFadeBuffers[2][i] = RGB5_B(b[0]) | RGB5_G(g[0]) | RGB5_R(r[0]);
     }
     DmaCopy16(3, gPaletteFadeBuffers[2], dest, arg2);
 }

--- a/src/main_board_launcher_and_cutscenes.c
+++ b/src/main_board_launcher_and_cutscenes.c
@@ -371,9 +371,9 @@ void RunEvolutionCutscene(void)
             {
                 for (i = 0; i < 16; i++)
                 {
-                    gPaletteFadeRGBCache[i][0] = gCurrentPinballGame->pauseObjPalette[13][i] & 0x1F;
-                    gPaletteFadeRGBCache[i][1] = (gCurrentPinballGame->pauseObjPalette[13][i] & 0x3E0) >> 5;
-                    gPaletteFadeRGBCache[i][2] = (gCurrentPinballGame->pauseObjPalette[13][i] & 0x7C00) >> 10;
+                    gPaletteFadeRGBCache[i][0] = RGB5_GET_R(gCurrentPinballGame->pauseObjPalette[13][i]);
+                    gPaletteFadeRGBCache[i][1] = RGB5_GET_G(gCurrentPinballGame->pauseObjPalette[13][i]);
+                    gPaletteFadeRGBCache[i][2] = RGB5_GET_B(gCurrentPinballGame->pauseObjPalette[13][i]);
                 }
             }
             else
@@ -385,7 +385,7 @@ void RunEvolutionCutscene(void)
                     sp210[0] = gPaletteFadeRGBCache[i][0] + ((0x1F - gPaletteFadeRGBCache[i][0]) * var0) / 30;
                     sp210[1] = gPaletteFadeRGBCache[i][1] + ((0x1F - gPaletteFadeRGBCache[i][1]) * var0) / 30;
                     sp210[2] = gPaletteFadeRGBCache[i][2] + ((0x1F - gPaletteFadeRGBCache[i][2]) * var0) / 30;
-                    destColor[i] = sp210[0] | (sp210[1] << 5) | (sp210[2] << 0xA);
+                    destColor[i] = RGB5_R(sp210[0]) | RGB5_G(sp210[1]) | RGB5_B(sp210[2]);
                 }
 
                 DmaCopy16(3, destColor, (void *)0x050003A0, 0x20);


### PR DESCRIPTION
## Description
Adds helper functions for the few RGB handling spots (reading from a representation with 3 5bit parts packed in a single u16) - done mainly to remove the need for the magic consts/shift involved with pulling/setting the appropriate bits.

Note: when repacking, I see 3 functions that pack in one order, and 2 functions packing in a reverse of that order. This does end up affecting compilation... so I went with individual defined functions for each piece, rather than a consolidated 'pack' function.

## **Discord username**
retnuhytnuob