### PR TITLE
Add helper for working with trig math

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -41,18 +41,11 @@ s16 Cos(u16 arg0);
    Use the MulNegSinSpecial for those cases */
 #define MulSin(value, angle) (((value) * (Sin(angle))) / TRIG_SCALE)
 
-/* Multiply value by cos(angle).
-   Works in most cases; compiles differently with some values, like -100, where the negative
-   plus optimizer pre-reduction causes it to fall in a different position.
-   Use the MulNegCosSpecial for those cases
-*/
+/* Multiply value by cos(angle).*/
 #define MulCos(value, angle) (((value) * (Cos(angle))) / TRIG_SCALE)
 
 // Multiply value by sin(angle).
 #define MulNegSinSpecial(value, angle) (-((Sin(angle)) * (value)) / TRIG_SCALE)
-
-// Multiply value by cos(angle).
-#define MulNegCosSpecial(value, angle) (-((Cos(angle)) * (value)) / TRIG_SCALE)
 
 void DisableVBlankInterrupts(void);
 void MainLoopIter(void);

--- a/include/functions.h
+++ b/include/functions.h
@@ -30,6 +30,30 @@ void Timer3Intr(void);
 void IntrDummy(void);
 s16 Sin(u16 arg0);
 s16 Cos(u16 arg0);
+
+// sin table produces values from 0 - 20000
+#define TRIG_SCALE 20000
+
+/* Multiply value by sin(angle).
+
+   Works in most cases; compiles differently with some values, like -100, where the negative
+   plus optimizer pre-reduction causes it to fall in a different position.
+   Use the MulNegSinSpecial for those cases */
+#define MulSin(value, angle) (((value) * (Sin(angle))) / TRIG_SCALE)
+
+/* Multiply value by cos(angle).
+   Works in most cases; compiles differently with some values, like -100, where the negative
+   plus optimizer pre-reduction causes it to fall in a different position.
+   Use the MulNegCosSpecial for those cases
+*/
+#define MulCos(value, angle) (((value) * (Cos(angle))) / TRIG_SCALE)
+
+// Multiply value by sin(angle).
+#define MulNegSinSpecial(value, angle) (-((Sin(angle)) * (value)) / TRIG_SCALE)
+
+// Multiply value by cos(angle).
+#define MulNegCosSpecial(value, angle) (-((Cos(angle)) * (value)) / TRIG_SCALE)
+
 void DisableVBlankInterrupts(void);
 void MainLoopIter(void);
 void DefaultMainCallback(void);

--- a/include/functions.h
+++ b/include/functions.h
@@ -44,7 +44,7 @@ s16 Cos(u16 arg0);
 /* Multiply value by cos(angle).*/
 #define MulCos(value, angle) (((value) * (Cos(angle))) / TRIG_SCALE)
 
-// Multiply value by sin(angle).
+// Multiply -value by sin(angle). (used in cases where compile optimization order matters)
 #define MulNegSinSpecial(value, angle) (-((Sin(angle)) * (value)) / TRIG_SCALE)
 
 void DisableVBlankInterrupts(void);

--- a/src/all_board_mode_change_and_debug_menu.c
+++ b/src/all_board_mode_change_and_debug_menu.c
@@ -334,7 +334,7 @@ void BallSaverAnimation(void)
         if (gMain.animationTimer > 70)
         {
             int var0 = (gMain.animationTimer + 20) % 0x40;
-            gCurrentPinballGame->ballSaverPosY = (Sin(var0 * 0x400) * 500) / 20000;
+            gCurrentPinballGame->ballSaverPosY = MulSin(500, (var0 * 0x400));
             gCurrentPinballGame->ballSaverVelX = 10;
             gCurrentPinballGame->ballSaverVelY = 400;
         }

--- a/src/all_board_process5.c
+++ b/src/all_board_process5.c
@@ -63,8 +63,8 @@ extern const u16 gGravityDeltas_Light[4];
     maxSpeed = (max_speed);                              \
     if (squaredSpeed > maxSpeed * maxSpeed)              \
     {                                                    \
-        velocity.x =  (maxSpeed * Cos((angle))) / 20000; \
-        velocity.y = (-maxSpeed * Sin((angle))) / 20000; \
+        velocity.x = MulCos(maxSpeed,angle); \
+        velocity.y = MulSin(-maxSpeed,angle); \
     }                                                    \
     else                                                 \
     {                                                    \

--- a/src/all_board_process6_collision.c
+++ b/src/all_board_process6_collision.c
@@ -428,14 +428,18 @@ void ComputeWallReflection(u16 arg0, struct Vector16 *arg1, struct Vector16 *arg
         curveDirScaledFactor * scaledLateralMag / 0xEB8
         + gCurrentPinballGame->ball->spinAcceleration;
 
+/*
+    tempVec.x = MulCos(forwardMag, arg0) + MulCos(lateralMag, adjustedAngle);
+    tempVec.y = MulSin(-forwardMag, arg0) + MulSin(-lateralMag, adjustedAngle);
+*/
     tempVec.x =  forwardMag * Cos(arg0);
     tempVec.y = -forwardMag * Sin(arg0);
 
     tempVec.x =  lateralMag * Cos(adjustedAngle) + tempVec.x;
     tempVec.y = -lateralMag * Sin(adjustedAngle) + tempVec.y;
 
-    tempVec.x = tempVec.x / 20000;
-    tempVec.y = tempVec.y / 20000;
+    tempVec.x = tempVec.x / TRIG_SCALE;
+    tempVec.y = tempVec.y / TRIG_SCALE;
 
     // With how the curveSign/curveScaleFactor are only used 'multiplied together'
     // with the tempVec calculation, the negations cancel out. - Shouldn't be needed.
@@ -484,7 +488,6 @@ void ComputeWallReflection(u16 arg0, struct Vector16 *arg1, struct Vector16 *arg
 
 void ApplyBounceBackForce(u16 arg0, struct Vector32 *arg1, u16 arg2)
 {
-    const u16 VECTORSCALEDOWN = 20000;
     s32 squaredSpeed;
     s16 x, y;
     s16 var0;

--- a/src/all_board_process6_collision.c
+++ b/src/all_board_process6_collision.c
@@ -215,7 +215,7 @@ void ApplyTiltEffectOnCollision(struct Vector16 *ballPosition, struct Vector16 *
             cos = Cos(angle);
             if (cos < 0)
             {
-                arg1->x = (Cos(angle) * 70) / 20000;
+                arg1->x = MulCos(70, angle);
                 gCurrentPinballGame->tiltLockoutTimer = 1;
             }
         }
@@ -224,7 +224,7 @@ void ApplyTiltEffectOnCollision(struct Vector16 *ballPosition, struct Vector16 *
             cos = Cos(angle);
             if (cos > 0)
             {
-                arg1->x = (Cos(angle) * 70) / 20000;
+                arg1->x = MulCos(70, angle);
                 gCurrentPinballGame->tiltLockoutTimer = 1;
             }
         }
@@ -524,13 +524,13 @@ void ApplyBounceBackForce(u16 arg0, struct Vector32 *arg1, u16 arg2)
 
             if ( gCurrentPinballGame->ballSpeed > 0)
             {
-                tempVec.x = 230 * Cos(arg0) / VECTORSCALEDOWN;
-                tempVec.y = -230 * Sin(arg0) / VECTORSCALEDOWN;
+                tempVec.x = MulCos(230, arg0);
+                tempVec.y = MulSin(-230, arg0);
             }
             else
             {
-                tempVec.x = 285 * Cos(arg0) / VECTORSCALEDOWN;
-                tempVec.y = -285 * Sin(arg0) / VECTORSCALEDOWN;
+                tempVec.x = MulCos(285, arg0);
+                tempVec.y = MulSin(-285, arg0);
             }
 
             gCurrentPinballGame->slingshotHitAnimTimer = 4;
@@ -549,24 +549,24 @@ void ApplyBounceBackForce(u16 arg0, struct Vector32 *arg1, u16 arg2)
 
             if (arg0 > 0xA000 && arg0 < 0xE000)
             {
-                tempVec.x =  60 * Cos(arg0) / VECTORSCALEDOWN;
-                tempVec.y = -60 * Sin(arg0) / VECTORSCALEDOWN;
+                tempVec.x = MulCos(60, arg0);
+                tempVec.y = MulSin(-60, arg0);
             }
             else if (arg0 >= 0x1000 && arg0 <= 0x7000)
             {
-                tempVec.x =  240 * Cos(arg0) / VECTORSCALEDOWN;
-                tempVec.y = -240 * Sin(arg0) / VECTORSCALEDOWN;
+                tempVec.x = MulCos(240, arg0);
+                tempVec.y = MulSin(-240, arg0);
             }
             else
             {
-                tempVec.x =  120 * Cos(arg0) / VECTORSCALEDOWN;
-                tempVec.y = -120 * Sin(arg0) / VECTORSCALEDOWN;
+                tempVec.x = MulCos(120, arg0);
+                tempVec.y = MulSin(-120, arg0);
             }
         }
         else
         {
-            tempVec.x =  gBounceBackForceMagnitudes[gCurrentPinballGame->collisionSurfaceType] * Cos(arg0) / VECTORSCALEDOWN;
-            tempVec.y = -gBounceBackForceMagnitudes[gCurrentPinballGame->collisionSurfaceType] * Sin(arg0) / VECTORSCALEDOWN;
+            tempVec.x = MulCos(gBounceBackForceMagnitudes[gCurrentPinballGame->collisionSurfaceType], arg0);
+            tempVec.y = MulSin(-gBounceBackForceMagnitudes[gCurrentPinballGame->collisionSurfaceType], arg0);
         }
     }
 
@@ -599,8 +599,8 @@ void ApplyBounceBackForce(u16 arg0, struct Vector32 *arg1, u16 arg2)
 
         gCurrentPinballGame->ball->spinSpeed = 0;
         angle = ArcTan2(arg1->x, -arg1->y);
-        arg1->x = squaredSpeed  * Cos(angle) / VECTORSCALEDOWN;
-        arg1->y = -squaredSpeed  * Sin(angle) / VECTORSCALEDOWN;
+        arg1->x = MulCos(squaredSpeed, angle);
+        arg1->y = MulSin(-squaredSpeed, angle);
     }
 }
 
@@ -848,8 +848,8 @@ void ProcessBonusTrapPhysics(void)
     {
         angle = ArcTan2(-vec1.x, vec1.y);
         temp_adjust = 30;
-        vec2.x = (temp_adjust  * Cos(angle)) / 20000;
-        vec2.y = (-temp_adjust * Sin(angle)) / 20000;
+        vec2.x = MulCos(temp_adjust, angle);
+        vec2.y = MulSin(-temp_adjust, angle);
         gCurrentPinballGame->ball->velocity.x = ((vec2.x * 100) + (98 * gCurrentPinballGame->ball->velocity.x)) / 100;
         gCurrentPinballGame->ball->velocity.y = ((vec2.y * 100) + (98 * gCurrentPinballGame->ball->velocity.y)) / 100;
     }
@@ -966,8 +966,8 @@ void ComputeFlipperLaunchVelocity(s32 arg0, s16 flipperIx, struct Vector16* arg2
             angle = (gCurrentPinballGame->ball->velocity.x * -0x600) / 0x80 +
                     (gCurrentPinballGame->ball->prevSpinSpeed * -0x180) / 0x100 +
                     var0;
-            gCurrentPinballGame->flipperLaunchVelocity.x = scale * Cos(angle) / 20000;
-            gCurrentPinballGame->flipperLaunchVelocity.y = -scale * Sin(angle) / 20000;
+            gCurrentPinballGame->flipperLaunchVelocity.x = MulCos(scale, angle);
+            gCurrentPinballGame->flipperLaunchVelocity.y = MulSin(-scale, angle);
         }
 
         gCurrentPinballGame->flipperLaunchPending = TRUE;
@@ -986,14 +986,14 @@ void ComputeFlipperLaunchVelocity(s32 arg0, s16 flipperIx, struct Vector16* arg2
         u16 angle2;
 
         scale = arg0 / 20;
-        vec1.x = scale * Cos(arg3) / 20000;
-        vec1.y = -(scale * Sin(arg3)) / 20000;
+        vec1.x = MulCos(scale, arg3);
+        vec1.y = MulNegSinSpecial(scale, arg3);
 
         arg2->x = vec1.x + arg2->x * 3 / 2;
         arg2->y = vec1.y + arg2->y * 3 / 2;
 
         angle2 = ArcTan2(arg2->x, -arg2->y);
-        arg2->x = scale * Cos(angle2) / 20000;
-        arg2->y = -scale * Sin(angle2) / 20000;
+        arg2->x = MulCos(scale, angle2);
+        arg2->y = MulSin(-scale, angle2);
     }
 }

--- a/src/all_board_process6_collision.c
+++ b/src/all_board_process6_collision.c
@@ -236,16 +236,16 @@ void ApplyTiltEffectOnCollision(struct Vector16 *ballPosition, struct Vector16 *
         if (gCurrentPinballGame->ball->positionQ0.y > 364)
         {
             if (gCurrentPinballGame->tiltTargetXOffset == 0)
-                arg1->y = -(Sin(angle) * 130) / 20000;
+                arg1->y = MulSin(-130, angle);
             else
-                arg1->y = -(Sin(angle) * 100) / 20000;
+                arg1->y = MulNegSinSpecial(100, angle);
         }
         else
         {
             if (gCurrentPinballGame->tiltTargetXOffset == 0)
-                arg1->y = -(Sin(angle) * 100) / 20000;
+                arg1->y = MulNegSinSpecial(100, angle);
             else
-                arg1->y = -(Sin(angle) * 75) / 20000;
+                arg1->y = MulSin(-75, angle);
 
             if (arg1->y >= 90)
                 gCurrentPinballGame->ball->velocity.x /= 4;
@@ -395,8 +395,8 @@ void ComputeWallReflection(u16 arg0, struct Vector16 *arg1, struct Vector16 *arg
 
     // Project a curved arg2 delta based on half the magnitude
     // Note: the trigonometric functions return s16, typically scaled by 0x1000 or more
-    lateralMag = halfMag * Sin(angleDelta) / 20000;
-    forwardMag = halfMag * Cos(angleDelta) / 20000;
+    lateralMag = MulSin(halfMag, angleDelta);
+    forwardMag = MulCos(halfMag, angleDelta);
 
     // 'wall' sound if collision angle is high enough
     if (Cos(angleDelta)  > 0x1F3F)
@@ -449,8 +449,8 @@ void ComputeWallReflection(u16 arg0, struct Vector16 *arg1, struct Vector16 *arg
     }
     curveSign = curveDir * curveSign;
 
-    tempVec2.x =  curveSign * curveScaleFactor * Cos(adjustedAngle) / 20000;
-    tempVec2.y = -curveSign * curveScaleFactor * Sin(adjustedAngle) / 20000;
+    tempVec2.x = MulCos(curveSign * curveScaleFactor, adjustedAngle);
+    tempVec2.y = MulSin( -curveSign * curveScaleFactor, adjustedAngle);
 
     vxSquared = tempVec.x * tempVec.x;
     vySquared = tempVec.y * tempVec.y;
@@ -467,13 +467,13 @@ void ComputeWallReflection(u16 arg0, struct Vector16 *arg1, struct Vector16 *arg
         && gCurrentPinballGame->boardLayerDepth > 0
         && gCurrentPinballGame->ball->positionQ0.y < 0xD2)
     {
-        tempVec.x =  halfMag * Cos(finalAngle) / 20000;
-        tempVec.y = -halfMag * Sin(finalAngle) / 20000;
+        tempVec.x = MulCos(halfMag, finalAngle);
+        tempVec.y = MulSin(-halfMag, finalAngle);
     }
     else
     {
-        tempVec.x =  halfMag2 * Cos(finalAngle) / 20000;
-        tempVec.y = -halfMag2 * Sin(finalAngle) / 20000;
+        tempVec.x = MulCos(halfMag2, finalAngle);
+        tempVec.y = MulSin(-halfMag2, finalAngle);
     }
 
     ApplyBounceBackForce(arg0, &tempVec, angleOfFlippedArg1);

--- a/src/dusclops_process3.c
+++ b/src/dusclops_process3.c
@@ -948,9 +948,11 @@ void DusclopsPhase_ProcessEntityLogicAndGraphics(void)
 
             sl = (gCurrentPinballGame->trapSpinRadius * tr4) / 30;
 
-            gCurrentPinballGame->ball->positionQ8.x = (gCurrentPinballGame->catchTargetX * 256) + ((Cos(gCurrentPinballGame->trapAngleQ16) * sl) / 20000);
+            gCurrentPinballGame->ball->positionQ8.x = (gCurrentPinballGame->catchTargetX * 256)
+                + MulCos(sl, gCurrentPinballGame->trapAngleQ16);
 
-            gCurrentPinballGame->ball->positionQ8.y = (gCurrentPinballGame->catchTargetY * 256) - ((Sin(gCurrentPinballGame->trapAngleQ16) * sl) / 20000);
+            gCurrentPinballGame->ball->positionQ8.y = (gCurrentPinballGame->catchTargetY * 256)
+                - MulSin(sl, gCurrentPinballGame->trapAngleQ16);
 
             gCurrentPinballGame->ball->velocity.x = (gCurrentPinballGame->ball->velocity.x * 4) / 5;
             gCurrentPinballGame->ball->velocity.y = (gCurrentPinballGame->ball->velocity.y * 4) / 5;

--- a/src/groudon_process3.c
+++ b/src/groudon_process3.c
@@ -1112,8 +1112,8 @@ void UpdateGroudonFieldEntities(void)
                     PlayRumble(9);
                 }
 
-                gCurrentPinballGame->projectilePosition.x += (Cos(gCurrentPinballGame->projectileAngle) *  40) / 20000;
-                gCurrentPinballGame->projectilePosition.y += (Sin(gCurrentPinballGame->projectileAngle) * -40) / 20000;
+                gCurrentPinballGame->projectilePosition.x += MulCos(40, gCurrentPinballGame->projectileAngle);
+                gCurrentPinballGame->projectilePosition.y += MulSin(-40, gCurrentPinballGame->projectileAngle);
 
             }
             else
@@ -1656,8 +1656,8 @@ void UpdateGroudonFieldEntities(void)
                 && squaredDistance < gShockwaveSplashDistanceThresholds[gCurrentPinballGame->shockwaveAnimTimer])
             {
                 gCurrentPinballGame->trapAngleQ16 = ArcTan2(-tempVector.x, tempVector.y);
-                gCurrentPinballGame->ball->velocity.x = (Cos(gCurrentPinballGame->trapAngleQ16) * -400) / 20000;
-                gCurrentPinballGame->ball->velocity.y = (Sin(gCurrentPinballGame->trapAngleQ16) *  400) / 20000;
+                gCurrentPinballGame->ball->velocity.x = MulCos(-400, gCurrentPinballGame->trapAngleQ16);
+                gCurrentPinballGame->ball->velocity.y = MulSin(400, gCurrentPinballGame->trapAngleQ16);
                 PlayRumble(9);
             }
         }

--- a/src/kecleon_process3.c
+++ b/src/kecleon_process3.c
@@ -234,7 +234,6 @@ void KecleonBoardProcess_3B_35AA4(void)
 
 void UpdateKecleonEntityLogic(void)
 {
-    const u16 VECTORSCALEDOWN = 20000;
     int deltaX;
     int deltaY;
     struct Vector32 tempVec;

--- a/src/kecleon_process3.c
+++ b/src/kecleon_process3.c
@@ -346,8 +346,8 @@ void UpdateKecleonEntityLogic(void)
         yy = deltaVec.y * deltaVec.y;
         squaredDistance = xx + yy;
         angle = ArcTan2(deltaVec.x, -deltaVec.y);
-        tempVec.x = 6 * Cos(angle) / VECTORSCALEDOWN;
-        tempVec.y = -6 * Sin(angle) / VECTORSCALEDOWN;
+        tempVec.x = MulCos(6, angle);
+        tempVec.y = MulSin(-6, angle);
         gCurrentPinballGame->bossPositionX += tempVec.x;
         gCurrentPinballGame->bossPositionY += tempVec.y;
         if (squaredDistance < 2500)
@@ -411,8 +411,9 @@ void UpdateKecleonEntityLogic(void)
         yy = deltaVec.y * deltaVec.y;
         squaredDistance = xx + yy;
         angle = ArcTan2(deltaVec.x, -deltaVec.y);
-        tempVec.x = 10 * Cos(angle) / VECTORSCALEDOWN;
-        tempVec.y = -10 * Sin(angle) / VECTORSCALEDOWN;
+        tempVec.x = MulCos(10, angle);
+        tempVec.y = MulSin(-10, angle);
+
         gCurrentPinballGame->bossPositionX += tempVec.x;
         gCurrentPinballGame->bossPositionY += tempVec.y;
         if (squaredDistance < 2500)

--- a/src/kyogre_process3.c
+++ b/src/kyogre_process3.c
@@ -1122,8 +1122,12 @@ void UpdateKyogreFieldEntities(void)
                 var5 = (gCurrentPinballGame->trapSpinRadius * var4) / 30;
                 tempVector2.x = gCurrentPinballGame->vortexScreenPosition[i].x / 10 + 120;
                 tempVector2.y = gCurrentPinballGame->vortexScreenPosition[i].y / 10 + 144;
-                gCurrentPinballGame->ball->positionQ8.x = (tempVector2.x << 8) + ((Cos(gCurrentPinballGame->trapAngleQ16) * var5) / 20000);
-                gCurrentPinballGame->ball->positionQ8.y = (tempVector2.y << 8) - ((Sin(gCurrentPinballGame->trapAngleQ16) * var5) / 20000);
+
+                gCurrentPinballGame->ball->positionQ8.x = (tempVector2.x << 8)
+                    + MulCos(var5, gCurrentPinballGame->trapAngleQ16);
+                gCurrentPinballGame->ball->positionQ8.y = (tempVector2.y << 8)
+                    - MulSin(var5, gCurrentPinballGame->trapAngleQ16);
+
                 gCurrentPinballGame->ball->velocity.x = (gCurrentPinballGame->ball->velocity.x * 4) / 5;
                 gCurrentPinballGame->ball->velocity.y = (gCurrentPinballGame->ball->velocity.y * 4) / 5;
 
@@ -1148,8 +1152,11 @@ void UpdateKyogreFieldEntities(void)
                 var5 = (gCurrentPinballGame->trapSpinRadius * var4) / 47;
                 tempVector2.x = gCurrentPinballGame->vortexScreenPosition[i].x / 10 + 120;
                 tempVector2.y = gCurrentPinballGame->vortexScreenPosition[i].y / 10 + 144;
-                gCurrentPinballGame->ball->positionQ8.x = (tempVector2.x << 8) + ((Cos(gCurrentPinballGame->trapAngleQ16) * var5) / 20000);
-                gCurrentPinballGame->ball->positionQ8.y = (tempVector2.y << 8) - ((Sin(gCurrentPinballGame->trapAngleQ16) * var5) / 20000);
+
+                gCurrentPinballGame->ball->positionQ8.x = (tempVector2.x << 8)
+                    + MulCos(var5, gCurrentPinballGame->trapAngleQ16);
+                gCurrentPinballGame->ball->positionQ8.y = (tempVector2.y << 8)
+                    - MulSin(var5, gCurrentPinballGame->trapAngleQ16);
                 gCurrentPinballGame->ball->velocity.x = (gCurrentPinballGame->ball->velocity.x * 4) / 5;
                 gCurrentPinballGame->ball->velocity.y = (gCurrentPinballGame->ball->velocity.y * 4) / 5;
 
@@ -1190,8 +1197,8 @@ void UpdateKyogreFieldEntities(void)
                 yy = tempVector.y * tempVector.y;
                 squaredDistance = xx + yy;
                 angle = ArcTan2(tempVector.x, -tempVector.y);
-                tempVector3.x =  (Cos(angle) * 4) / 20000;
-                tempVector3.y = -(Sin(angle) * 4) / 20000;
+                tempVector3.x = MulCos(4, angle);
+                tempVector3.y = MulSin(-4, angle);
                 gCurrentPinballGame->vortexScreenPosition[i].x += tempVector3.x;
                 gCurrentPinballGame->vortexScreenPosition[i].y += tempVector3.y;
                 if (squaredDistance < 2500)

--- a/src/main.c
+++ b/src/main.c
@@ -203,6 +203,11 @@ s16 Cos(u16 arg0)
     return Sin(arg0 + 0x4000);
 }
 
+// sin table produces values from 0 - 20000
+//#define TRIG_SCALE 20000
+
+
+
 static void ReadKeys(void)
 {
     u16 keyInput = ~REG_KEYINPUT;
@@ -291,7 +296,7 @@ void DefaultMainCallback(void)
     if (REG_DISPSTAT & DISPSTAT_VBLANK_INTR)
     {
         VBlankIntrWait();
-        DmaCopy32(3, gOamBuffer, (void *)OAM, OAM_SIZE);
+        DmaCopy32(3, gOamBuffer, OAM, OAM_SIZE);
         REG_DISPCNT = gMain.dispcntBackup;
         REG_BG0HOFS = gMain.bgOffsets[0].xOffset;
         REG_BG0VOFS = gMain.bgOffsets[0].yOffset;

--- a/src/main.c
+++ b/src/main.c
@@ -203,11 +203,6 @@ s16 Cos(u16 arg0)
     return Sin(arg0 + 0x4000);
 }
 
-// sin table produces values from 0 - 20000
-//#define TRIG_SCALE 20000
-
-
-
 static void ReadKeys(void)
 {
     u16 keyInput = ~REG_KEYINPUT;

--- a/src/main_board_catch_normal_and_jirachi_modes.c
+++ b/src/main_board_catch_normal_and_jirachi_modes.c
@@ -497,15 +497,15 @@ void UpdateJirachiBonus(void)
             }
             else
             {
-                tempVec.x = (Cos(angle) *  7) / 20000;
-                tempVec.y = (Sin(angle) * -7) / 20000;
+                tempVec.x = MulCos(7, angle);
+                tempVec.y = MulSin(-7, angle);
             }
 
             gCurrentPinballGame->jirachiLogicX += tempVec.x;
             gCurrentPinballGame->jirachiLogicY += tempVec.y;
             var0 = ((gCurrentPinballGame->stageTimer % 80) << 0x10) / 80;
             gCurrentPinballGame->jirachiDisplayX = gCurrentPinballGame->jirachiLogicX;
-            gCurrentPinballGame->jirachiDisplayY = gCurrentPinballGame->jirachiLogicY + (Sin(var0) * 60) / 20000;
+            gCurrentPinballGame->jirachiDisplayY = gCurrentPinballGame->jirachiLogicY + MulSin(60, var0);
         }
 
         if (gCurrentPinballGame->stageTimer < 500)

--- a/src/main_board_center_capture_hole.c
+++ b/src/main_board_center_capture_hole.c
@@ -750,10 +750,10 @@ void RunMonCaptureSequence(void)
         {
             s32 var_3 = (gCurrentPinballGame->trapSpinRadius * temp_r0) / 80;
 
-            gCurrentPinballGame->ball->positionQ8.x =
-                (gCurrentPinballGame->catchTargetX << 8) + Cos(gCurrentPinballGame->trapAngleQ16) * var_3 / 20000;
-            gCurrentPinballGame->ball->positionQ8.y =
-                (gCurrentPinballGame->catchTargetY << 8) - Sin(gCurrentPinballGame->trapAngleQ16) * var_3 / 20000;
+            gCurrentPinballGame->ball->positionQ8.x = (gCurrentPinballGame->catchTargetX << 8)
+                + MulCos(var_3, gCurrentPinballGame->trapAngleQ16);
+            gCurrentPinballGame->ball->positionQ8.y = (gCurrentPinballGame->catchTargetY << 8)
+                - MulSin(var_3, gCurrentPinballGame->trapAngleQ16);
         }
         break;
 

--- a/src/main_board_launcher_and_cutscenes.c
+++ b/src/main_board_launcher_and_cutscenes.c
@@ -734,8 +734,8 @@ void RunTravelEventCutscene(void)
         if (gCurrentPinballGame->stageTimer < 60)
         {
             u16 angle = (gCurrentPinballGame->stageTimer * 0x4000) / 60;
-            gCurrentPinballGame->travelPainterPosX = (Cos(angle) * 900) / 20000 + 487;
-            gCurrentPinballGame->travelPainterPosY = (Sin(angle) * 600) / 20000 - 629;
+            gCurrentPinballGame->travelPainterPosX = MulCos(900, angle) + 487;
+            gCurrentPinballGame->travelPainterPosY = MulSin(600, angle) - 629;
             gCurrentPinballGame->travelPainterVelX = -17;
             gCurrentPinballGame->travelPainterVelY = -30;
             index = (gCurrentPinballGame->stageTimer % 4) / 2;

--- a/src/main_board_pichu_entity.c
+++ b/src/main_board_pichu_entity.c
@@ -159,7 +159,7 @@ void UpdateKickbackLogic(void)
 
             // used for the horizontal 'floaty' movement when electric builds pre-launch.
             gCurrentPinballGame->ball->positionQ1.x =
-                gCurrentPinballGame->kickbackBallHoverPos.x + ((Sin(r5) * 6) / 20000) +
+                gCurrentPinballGame->kickbackBallHoverPos.x + MulSin(6, r5) +
                 ((gOutlaneCenterXPositions[gCurrentPinballGame->outLaneSide - 1] * 2 - gCurrentPinballGame->kickbackBallHoverPos.x) * (gCurrentPinballGame->kickbackAnimDuration - gCurrentPinballGame->kickbackAnimProgress)) / gCurrentPinballGame->kickbackAnimDuration;
 
             tempY = ((gCurrentPinballGame->kickbackAnimDuration - gCurrentPinballGame->kickbackAnimProgress) * 40) / gCurrentPinballGame->kickbackAnimDuration;
@@ -369,8 +369,8 @@ void PichuArrivalSequence(void)
         yy = tempVec.y * tempVec.y;
         squaredDistance = xx + yy;
         angle = ArcTan2(tempVec.x, -tempVec.y);
-        tempVec2.x = (Cos(angle) * 7) / 20000;
-        tempVec2.y = (Sin(angle) * -7) / 20000;
+        tempVec2.x = MulCos(7, angle);
+        tempVec2.y = MulSin(-7, angle);
         index = gAngleToDirectionTable[angle / ANGLE_45] + (gMain.systemFrameCount % 24) / 8;
         gCurrentPinballGame->walkMonXPos += tempVec2.x;
         gCurrentPinballGame->walkMonYPos += tempVec2.y;

--- a/src/main_board_to_be_split.c
+++ b/src/main_board_to_be_split.c
@@ -1764,14 +1764,14 @@ void UpdateEggMode(void)
             if (gCurrentPinballGame->creatureWaypointIndex < 4)
             {
                 var0 = 0;
-                tempVec2.x = (Cos(angle) * 14) / 20000;
-                tempVec2.y = -(Sin(angle) * 14) / 20000;
+                tempVec2.x = MulCos(14, angle);
+                tempVec2.y = MulSin(-14, angle);
             }
             else
             {
                 var0 = gAngleToDirectionTable[angle / ANGLE_45] + (gMain.systemFrameCount % 24) / 8;
-                tempVec2.x = (Cos(angle) * 7) / 20000;
-                tempVec2.y = -(Sin(angle) * 7) / 20000;
+                tempVec2.x = MulCos(7, angle);
+                tempVec2.y = MulSin(-7, angle);
             }
 
             gCurrentPinballGame->walkMonXPos += tempVec2.x;
@@ -1826,8 +1826,8 @@ void UpdateEggMode(void)
         yy = tempVec.y * tempVec.y;
         squaredDistance = xx + yy;
         angle = ArcTan2(tempVec.x, -tempVec.y);
-        tempVec2.x = (Cos(angle) * 7) / 20000;
-        tempVec2.y = -(Sin(angle) * 7) / 20000;
+        tempVec2.x = MulCos(7, angle);
+        tempVec2.y = MulSin(-7, angle);
         if (gCurrentPinballGame->captureFlashTimer)
         {
             gCurrentPinballGame->captureFlashTimer--;
@@ -1919,13 +1919,13 @@ void UpdateEggMode(void)
                 angle2 = ArcTan2(-gCurrentPinballGame->ball->velocity.x, gCurrentPinballGame->ball->velocity.y);
                 if (gCurrentPinballGame->creatureHitCount > 1)
                 {
-                    gCurrentPinballGame->ball->velocity.x = (Cos(angle2) * 400) / 20000;
-                    gCurrentPinballGame->ball->velocity.y = -(Sin(angle2) * 400) / 20000;
+                    gCurrentPinballGame->ball->velocity.x = MulCos(400, angle2);
+                    gCurrentPinballGame->ball->velocity.y = MulSin(-400, angle2);
                 }
                 else
                 {
-                    gCurrentPinballGame->ball->velocity.x = (Cos(angle2) * 160) / 20000;
-                    gCurrentPinballGame->ball->velocity.y = -(Sin(angle2) * 160) / 20000;
+                    gCurrentPinballGame->ball->velocity.x = MulCos(160, angle2);
+                    gCurrentPinballGame->ball->velocity.y = MulSin(-160, angle2);
                 }
 
                 PlayRumble(7);

--- a/src/rayquaza_process3.c
+++ b/src/rayquaza_process3.c
@@ -441,7 +441,7 @@ void UpdateRayquazaEntityLogic(void)
         if (gCurrentPinballGame->bossMovementPhase > 1)
         {
             gCurrentPinballGame->bossSineAngle += 0x80;
-            gCurrentPinballGame->bossPositionX = ((Sin(gCurrentPinballGame->bossSineAngle) * 62) / 20000) * 10;
+            gCurrentPinballGame->bossPositionX = MulSin(62, gCurrentPinballGame->bossSineAngle) * 10;
         }
         break;
     case RAYQUAZA_ENTITY_STATE_LIGHTNING_ATTACK:
@@ -1268,8 +1268,10 @@ void UpdateRayquazaMinionsAndEffects(void)
             {
 
                 s16 angle = (((gMain.systemFrameCount + 120 * i) % 240) << 0x10) / 240;
-                gCurrentPinballGame->vortexScreenPosition[i].x = gCurrentPinballGame->vortexOrbitCenter[i].x + (Cos(angle) * 4) / 2000;
-                gCurrentPinballGame->vortexScreenPosition[i].y = gCurrentPinballGame->vortexOrbitCenter[i].y + (Sin(angle) * 4) / 2000;
+                gCurrentPinballGame->vortexScreenPosition[i].x = gCurrentPinballGame->vortexOrbitCenter[i].x
+                    + MulCos(40, angle);
+                gCurrentPinballGame->vortexScreenPosition[i].y = gCurrentPinballGame->vortexOrbitCenter[i].y
+                    + MulSin(40, angle);
 
                 tempVector.x = gCurrentPinballGame->ball->positionQ0.x - (gCurrentPinballGame->vortexScreenPosition[i].x / 10) - 16;
                 tempVector.y = gCurrentPinballGame->ball->positionQ0.y - (gCurrentPinballGame->vortexScreenPosition[i].y / 10) - 32;;
@@ -1334,8 +1336,10 @@ void UpdateRayquazaMinionsAndEffects(void)
             var5 = (gCurrentPinballGame->trapSpinRadius * var4) / 30;
             tempVector2.x = gCurrentPinballGame->vortexScreenPosition[i].x / 10 + 16;
             tempVector2.y = gCurrentPinballGame->vortexScreenPosition[i].y / 10 + 32;
-            gCurrentPinballGame->ball->positionQ8.x = (tempVector2.x << 8) + ((Cos(gCurrentPinballGame->trapAngleQ16) * var5) / 20000);
-            gCurrentPinballGame->ball->positionQ8.y = (tempVector2.y << 8) - ((Sin(gCurrentPinballGame->trapAngleQ16) * var5) / 20000);
+            gCurrentPinballGame->ball->positionQ8.x = (tempVector2.x << 8)
+                + MulCos(var5, gCurrentPinballGame->trapAngleQ16);
+            gCurrentPinballGame->ball->positionQ8.y = (tempVector2.y << 8)
+                - MulSin(var5, gCurrentPinballGame->trapAngleQ16);
             gCurrentPinballGame->ball->velocity.x = (gCurrentPinballGame->ball->velocity.x * 4) / 5;
             gCurrentPinballGame->ball->velocity.y = (gCurrentPinballGame->ball->velocity.y * 4) / 5;
 
@@ -1765,8 +1769,10 @@ void RenderWindCloudSprites(void)
             var0 = ((gMain.systemFrameCount % 240) << 0x10) / 240;
             gCurrentPinballGame->vortexOrbitCenter[0].x = gRayquazaTornadoSpawnPos[rand].x;
             gCurrentPinballGame->vortexOrbitCenter[0].y = gRayquazaTornadoSpawnPos[rand].y;
-            gCurrentPinballGame->vortexScreenPosition[0].x = gCurrentPinballGame->vortexOrbitCenter[0].x + (Cos(var0) * 4) / 2000;
-            gCurrentPinballGame->vortexScreenPosition[0].y = gCurrentPinballGame->vortexOrbitCenter[0].y + (Sin(var0) * 4) / 2000;
+            gCurrentPinballGame->vortexScreenPosition[0].x = gCurrentPinballGame->vortexOrbitCenter[0].x
+                + MulCos(40, var0);
+            gCurrentPinballGame->vortexScreenPosition[0].y = gCurrentPinballGame->vortexOrbitCenter[0].y
+                + MulSin(40, var0);
             m4aSongNumStart(SE_RAYQUAZA_SONIC_BOOM);
         }
     }
@@ -1782,8 +1788,10 @@ void RenderWindCloudSprites(void)
             var0 = (((gMain.systemFrameCount + 120) % 240) << 0x10) / 240;
             gCurrentPinballGame->vortexOrbitCenter[1].x = gRayquazaTornadoSpawnPos[rand].x;
             gCurrentPinballGame->vortexOrbitCenter[1].y = gRayquazaTornadoSpawnPos[rand].y;
-            gCurrentPinballGame->vortexScreenPosition[1].x = gCurrentPinballGame->vortexOrbitCenter[1].x + (Cos(var0) * 4) / 2000;
-            gCurrentPinballGame->vortexScreenPosition[1].y = gCurrentPinballGame->vortexOrbitCenter[1].y + (Sin(var0) * 4) / 2000;
+            gCurrentPinballGame->vortexScreenPosition[1].x = gCurrentPinballGame->vortexOrbitCenter[1].x
+                + MulCos(40, var0);
+            gCurrentPinballGame->vortexScreenPosition[1].y = gCurrentPinballGame->vortexOrbitCenter[1].y
+                + MulSin(40, var0);
             m4aSongNumStart(SE_RAYQUAZA_SONIC_BOOM);
         }
     }

--- a/src/ruby_process3_entities_2.c
+++ b/src/ruby_process3_entities_2.c
@@ -642,8 +642,8 @@ void RubyPond_EntityLogic(void)
                 var1 = -var1;
 
             gCurrentPinballGame->bumperOrbitRadius = 180;
-            gCurrentPinballGame->rubyBumperLogicPosition[i].x = (gCurrentPinballGame->bumperOrbitRadius * Cos(angle)) / 20000 + 1380;
-            gCurrentPinballGame->rubyBumperLogicPosition[i].y = (gCurrentPinballGame->bumperOrbitRadius * Sin(angle)) / 20000 + 1500;
+            gCurrentPinballGame->rubyBumperLogicPosition[i].x = MulCos(gCurrentPinballGame->bumperOrbitRadius, angle) + 1380;
+            gCurrentPinballGame->rubyBumperLogicPosition[i].y = MulSin(gCurrentPinballGame->bumperOrbitRadius, angle) + 1500;
         }
         break;
     case RUBY_POND_STATE_CHINCHOU_COUNTERCLOCKWISE:
@@ -655,8 +655,8 @@ void RubyPond_EntityLogic(void)
                 var1 = -var1;
 
             gCurrentPinballGame->bumperOrbitRadius = 180;
-            gCurrentPinballGame->rubyBumperLogicPosition[i].x = (gCurrentPinballGame->bumperOrbitRadius * Cos(angle)) / 20000 + 1380;
-            gCurrentPinballGame->rubyBumperLogicPosition[i].y = (gCurrentPinballGame->bumperOrbitRadius * Sin(angle)) / 20000 + 1500;
+            gCurrentPinballGame->rubyBumperLogicPosition[i].x = MulCos(gCurrentPinballGame->bumperOrbitRadius, angle) + 1380;
+            gCurrentPinballGame->rubyBumperLogicPosition[i].y = MulSin(gCurrentPinballGame->bumperOrbitRadius, angle) + 1500;
         }
         break;
     case RUBY_POND_STATE_CHINCHOU_ROWS:
@@ -690,8 +690,8 @@ void RubyPond_EntityLogic(void)
         tempVec.y = gChinchouWaypointPositions[gCurrentPinballGame->chinchouWaypointTarget].y * 10 - gCurrentPinballGame->rubyBumperLogicPosition[0].y;
         squaredDistance = (tempVec.x * tempVec.x) + (tempVec.y * tempVec.y);
         angle2 = ArcTan2(tempVec.x, -tempVec.y);
-        tempVec2.x = (Cos(angle2) * 7) / 20000;
-        tempVec2.y = (Sin(angle2) * -7) / 20000;
+        tempVec2.x = MulCos(7, angle2);
+        tempVec2.y = MulSin(-7, angle2);
         gCurrentPinballGame->rubyBumperLogicPosition[0].x += tempVec2.x;
         gCurrentPinballGame->rubyBumperLogicPosition[0].y += tempVec2.y;
         if (squaredDistance < 2500)

--- a/src/ruby_trigger_targets.c
+++ b/src/ruby_trigger_targets.c
@@ -85,9 +85,10 @@ void UpdateChikoritaAttackAnimation(void)
             gCurrentPinballGame->chikoritaProjectileVelX -= 2;
             gCurrentPinballGame->chikoritaProjectileX += gCurrentPinballGame->chikoritaProjectileVelX;
             if (gCurrentPinballGame->chikoritaProjectileTimer < 30)
-                gCurrentPinballGame->chikoritaProjectileY = gCurrentPinballGame->chikoritaProjectileTimer + (Sin(var0) * 24) / 20000;
+                gCurrentPinballGame->chikoritaProjectileY = gCurrentPinballGame->chikoritaProjectileTimer
+                    + MulSin(24, var0);
             else
-                gCurrentPinballGame->chikoritaProjectileY = 30 + (Sin(var0) * 24) / 20000;
+                gCurrentPinballGame->chikoritaProjectileY = 30 + MulSin(24, var0);
 
             gCurrentPinballGame->chikoritaProjectileTimer++;
             if (gCurrentPinballGame->chikoritaProjectileTimer == 27)

--- a/src/sapphire_collision.c
+++ b/src/sapphire_collision.c
@@ -318,8 +318,8 @@ void ProcessSapphireCollisionEvent(u8 triggerType, u16* hasCollisionImpact, u16*
                     	gCurrentPinballGame->ball->velocity.y * gCurrentPinballGame->ball->velocity.y;
 
                 	squaredSpeed = Sqrt(squaredSpeed * 4) / 2;
-                	gCurrentPinballGame->ball->velocity.x = squaredSpeed * Cos(angle) / 20000;
-                	gCurrentPinballGame->ball->velocity.y = -squaredSpeed * Sin(angle) / 20000;
+                	gCurrentPinballGame->ball->velocity.x = MulCos(squaredSpeed, angle);
+                	gCurrentPinballGame->ball->velocity.y = MulSin(-squaredSpeed, angle);
                 }
             }
             else

--- a/src/sapphire_pond_and_zigzagoon.c
+++ b/src/sapphire_pond_and_zigzagoon.c
@@ -208,7 +208,7 @@ void UpdatePelipperPondEntity(void)
         break;
     case 8:
         var_sl = (gCurrentPinballGame->pelipperFrameTimer % 24) / 6 + 13;
-        gCurrentPinballGame->pelipperYBobOffset = (Sin(gCurrentPinballGame->pelipperFrameTimer * 0x400) * 240) / 20000;
+        gCurrentPinballGame->pelipperYBobOffset = MulSin(240, gCurrentPinballGame->pelipperFrameTimer * 0x400);
         if (gCurrentPinballGame->pelipperFrameTimer == 0)
             m4aSongNumStart(SE_PELIPPER_SWOOSH);
 

--- a/src/spheal_process3.c
+++ b/src/spheal_process3.c
@@ -1114,7 +1114,7 @@ void SphealBoard_PelipperDeliversBall(void)
     else
     {
         gCurrentPinballGame->deliveryAnimFrameIndex = (gCurrentPinballGame->pelipperFrameTimer % 24) / 6 + 13;
-        gCurrentPinballGame->pelipperYBobOffset = (Sin(gCurrentPinballGame->pelipperFrameTimer * 0x400) * 240) / 20000;
+        gCurrentPinballGame->pelipperYBobOffset = MulSin(240, gCurrentPinballGame->pelipperFrameTimer * 0x400);
         if (gCurrentPinballGame->pelipperFrameTimer == 0)
             m4aSongNumStart(SE_PELIPPER_SWOOSH);
 


### PR DESCRIPTION
## Description
Nearly all spots using Sin/Cos are using it with `(scale * Sin(angle)) / 20000)`
20000 is the max value that the sin function returns (When the Sin/Cols result would be '1')

This adds a helper function that does the structural 'Perform Sin/Con, then multiply, then scale down' that was littered across code.
One note: 2 call sites have the negative applied in a different order (between the multiplication and division, rather than as part of the division, or after it) - I made a MulNegSinSpecial for use in those spots.

I'm requesting a second opinion on whether this refactoring is actually helpful.

## **Discord username**
retnuhytnuob